### PR TITLE
docs: add internal architecture deep-dive with diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 > Deep-dive into how Claude Code is structured internally.
 
+> 📐 **Looking for the full code-grounded deep dive with architecture diagrams?**
+> See [`docs/internals/`](internals/README.md) — a 14-part guide (master Mermaid diagrams +
+> per-subsystem walkthroughs of the query loop, tools, permissions, MCP, agents, bridge, and more).
+
 ---
 
 ## High-Level Overview

--- a/docs/internals/01-startup.md
+++ b/docs/internals/01-startup.md
@@ -1,0 +1,145 @@
+# 01 — Startup & Entrypoints
+
+> From typing `claude` in a shell to a live interactive REPL. Covers the boot sequence,
+> the entrypoints, startup performance tricks, CLI flag parsing, and the global state singleton.
+
+← [Index](README.md) · Next → [02 — The Query Loop](02-query-loop.md)
+
+---
+
+## The boot sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Shell
+    participant CLI as entrypoints/cli.tsx
+    participant Main as main.tsx
+    participant Init as entrypoints/init.ts
+    participant Setup as setup.ts
+    participant RL as replLauncher.tsx
+    participant Ink as Ink renderer
+    participant Q as query.ts
+
+    Shell->>CLI: claude [args]
+    Note over CLI: fast-paths first<br/>(--version, daemon, bridge, mcp serve)
+    CLI->>Main: import + main() (fallthrough)
+    Note over Main: module-level side effects fire BEFORE heavy imports:<br/>startMdmRawRead(), startKeychainPrefetch()
+    Main->>Main: Commander program + preAction hook
+    Main->>Init: await init() (memoized)
+    Note over Init: config validation, env vars, OAuth,<br/>mTLS/proxy, API preconnect, shutdown handlers
+    Main->>Setup: setup()
+    Note over Setup: trust dialog, workspace/session root,<br/>permission context, scheduled-task watcher
+    Main->>RL: launchRepl(...)
+    RL->>Ink: render(<App><REPL/></App>)
+    loop each user prompt
+        Ink->>Q: query(prompt, context)
+        Q-->>Ink: yield stream events → re-render
+    end
+```
+
+Roughly: **process entry → fast-path check → full CLI load → `init()` → `setup()` → mount React/Ink → REPL drives `query()` per prompt.** Pre-REPL latency is on the order of a few hundred ms, heavily optimized by the prefetch tricks below.
+
+---
+
+## Entrypoints — what each does and when
+
+| Entrypoint | When it runs | Responsibility |
+|---|---|---|
+| **`src/entrypoints/cli.tsx`** | Always — the real process entry (`bin: claude`) | Cheap fast-paths *before* loading the world: `--version`, `--dump-system-prompt`, daemon workers, special MCP servers (chrome/computer-use), bridge mode. Falls through to `import('../main.js'); main()`. |
+| **`src/main.tsx`** | All interactive/print modes | The orchestrator: builds the Commander.js program, attaches the `preAction` hook, defines the default action handler, and launches the REPL. ~4,700 lines. |
+| **`src/entrypoints/init.ts`** | Once per session (memoized), via Commander `preAction` | Config validation, safe env vars, graceful-shutdown handlers, OAuth population, mTLS/proxy/HTTP-agent setup, **API preconnect** (warm TLS), CCR upstream proxy, scratchpad dir. Telemetry init is deferred to *after* the trust dialog. |
+| **`src/entrypoints/mcp.ts`** | `claude mcp serve` | Runs Claude Code **as an MCP server** over stdio, exposing its tools to other MCP clients. See [08 — MCP](08-mcp.md). |
+| **`src/entrypoints/sdk/`** | Imported by SDK consumers | Pure Zod schemas + TS types for SDK messages (init, control, hooks). No runtime logic — the real SDK execution lives in `server/` and `coordinator/`. |
+
+The fast-path design in `cli.tsx` matters: `claude --version` should load almost nothing, so the heavy module graph (`main.tsx` and everything it pulls in) is only imported on fallthrough.
+
+---
+
+## Startup optimizations (why it feels fast)
+
+The dominant trick is **firing slow side-effects in parallel before the heavy import chain runs**. In `src/main.tsx`, module-level calls kick off:
+
+- **`startMdmRawRead()`** — spawns MDM/policy subprocesses (`plutil` / `reg query`). They complete *during* the ~100ms+ import chain.
+- **`startKeychainPrefetch()`** — begins async macOS keychain reads (the biggest single blocker if left synchronous).
+
+Both are **awaited later**, in the Commander `preAction` hook, by which point they've usually finished. Additional overlapping work:
+
+- **API preconnect** (`init.ts`) — opens the TCP+TLS handshake to the Anthropic API in the background so the first model call doesn't pay for it.
+- **Commands + agents loading** — file-system walks run in parallel with `setup()`.
+- **Remote settings / policy limits** — loaded fire-and-forget; the session proceeds and hot-reloads them when they arrive (fail-open).
+- **GrowthBook flags** — read from a disk cache (`getFeatureValue_CACHED_MAY_BE_STALE`) so feature checks never block on the network.
+
+Mental model: *the critical path is "decide what model + mount the UI"; everything slow is shoved off the critical path and joined just-in-time.*
+
+---
+
+## CLI argument parsing
+
+Parsing happens in **two places**:
+
+1. **`cli.tsx` early fast-paths** — a handful of flags handled before Commander even loads.
+2. **`main.tsx` Commander program** — the full surface, parsed with `@commander-js/extra-typings`. The default `.action(...)` handler is the main prompt path; subcommands (`mcp`, `plugin`, `auth`, …) route to their own handlers.
+
+Representative flags and their effect:
+
+| Flag | Effect |
+|---|---|
+| `[prompt]` (positional) | The user's query; in `-p` mode runs headless, else seeds the REPL. |
+| `-p, --print` | Headless mode → routes to `src/cli/print.ts` instead of the interactive REPL. |
+| `--model <name>` | Override the main-loop model. May trigger a GrowthBook fetch to resolve aliases. |
+| `--continue` / `-c` | Resume the previous session transcript instead of starting fresh. |
+| `--worktree <dir>` | `chdir` into a git worktree and set the project root. |
+| `--agents <json>` | Inject/override agent definitions; merged with on-disk agents. |
+| `--mcp-config <file>` | MCP server config (overrides `.mcp.json`). |
+| `--settings <file>` | Apply flag-scoped settings (highest precedence source). |
+| `--add-dir <dir>` | Add a directory to CLAUDE.md/memory discovery. |
+| `--dangerously-skip-permissions` | Bypass permission prompts (see [06 — Permissions](06-permissions.md)). |
+| `--bare` | Minimal mode: skip hooks, LSP, plugin sync, auto-memory, keychain. |
+| `--output-format text\|json\|stream-json` | (print mode) output shape for SDK consumers. |
+
+How a flag becomes behavior: Commander parses → the action handler reads options → it sets fields in the **global state singleton** (below) and/or the `ToolUseContext` options → those flow into `query()`.
+
+---
+
+## Global state singleton — `src/bootstrap/state.ts`
+
+A single module-level `STATE` object holds everything that must be reachable without prop-drilling: session identity, cost/telemetry counters, model overrides, mode flags, and various caches. It is created once by `getInitialState()` and accessed exclusively through exported getters/setters (direct mutation is discouraged).
+
+Notable contents:
+
+```mermaid
+flowchart LR
+    subgraph STATE["bootstrap/state.ts — STATE singleton"]
+        ID["Session identity<br/>sessionId, projectRoot,<br/>cwd, originalCwd"]
+        COST["Telemetry & cost<br/>totalCostUSD, modelUsage,<br/>OTel counters"]
+        MODEL["Model config<br/>mainLoopModelOverride,<br/>initialMainLoopModel"]
+        MODE["Modes & flags<br/>isInteractive, bypassPermissions,<br/>sessionPersistenceDisabled"]
+        CACHE["Caches<br/>cachedClaudeMdContent,<br/>systemPromptSectionCache"]
+        EXT["Extensibility<br/>inlinePlugins, invokedSkills,<br/>registeredHooks, sessionCreatedTeams"]
+    end
+```
+
+Why a singleton (vs. React state): much of this is read from non-React code (the API client, tools, context builders, the permission engine). The REPL's `AppState` store (see [10 — UI](10-ui-state-rendering.md)) is the *React-reactive* state; `bootstrap/state.ts` is the *process-global* state. They are different and serve different layers — don't confuse them.
+
+Common accessors you'll meet everywhere: `getSessionId()`, `getCwd()` / `setCwdState()`, `getProjectRoot()`, `getTotalCostUSD()`, `getMainLoopModelOverride()`, `getInvokedSkills()`, `isSessionPersistenceDisabled()`.
+
+---
+
+## Where startup hands off to the engine
+
+Once `<App><REPL/></App>` is mounted, the REPL component (`src/screens/REPL.tsx`) owns the prompt loop. On each submission it calls the `query()` async generator (`src/query.ts:219`) and renders the events it yields. That handoff is the boundary between "startup" and "the engine" — continue in [02 — The Query Loop](02-query-loop.md).
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `main()` | `entrypoints/cli.tsx` | Process entry; fast-paths then fall through to `main.tsx`. |
+| `main()` / `run()` | `main.tsx` | Build Commander program, preAction hook, default action, launch REPL. |
+| `init()` | `entrypoints/init.ts` | Memoized config/env/network/OAuth initialization. |
+| `setup()` | `setup.ts` | Trust dialog, workspace + session root, permission context. |
+| `launchRepl()` | `replLauncher.tsx` | Dynamically import and mount the React/Ink app. |
+| `getInitialState()` / `STATE` | `bootstrap/state.ts` | The process-global state singleton + its factory. |
+| `startMdmRawRead()` / `startKeychainPrefetch()` | startup utils | Parallel prefetch fired before heavy imports. |

--- a/docs/internals/02-query-loop.md
+++ b/docs/internals/02-query-loop.md
@@ -1,0 +1,204 @@
+# 02 — The Query Loop (the LLM engine)
+
+> `src/query.ts` is the heart of Claude Code. This is the agentic loop: call the model,
+> run the tools it asks for, feed results back, repeat until it stops asking. Everything
+> else is machinery around this file.
+
+← [01 — Startup](01-startup.md) · [Index](README.md) · Next → [03 — Context & Prompts](03-context-and-prompts.md)
+
+---
+
+## The shape of it
+
+```ts
+// src/query.ts:219
+export async function* query(params: QueryParams):
+  AsyncGenerator<StreamEvent | RequestStartEvent | Message | TombstoneMessage | ToolUseSummaryMessage, Terminal>
+```
+
+`query()` is an **async generator**. It *yields* messages and stream-events as they happen
+(so the terminal UI can render live), and it *returns* a `Terminal` value (`{ reason: 'completed' | 'aborted_*' | 'max_turns' | ... }`) only when the turn is truly over.
+
+`query()` (line 219) is a thin wrapper; the real work is in `queryLoop()` (line 241), whose
+body is a `while (true)` loop starting at **line 307**. Each pass of that loop is one API
+round-trip plus the tool executions it triggers.
+
+State that survives between iterations is held in a single mutable `State` object (`src/query.ts:204`);
+each `continue` site rewrites `state = { ... }` rather than mutating nine separate variables.
+
+---
+
+## One iteration, step by step
+
+```mermaid
+flowchart TD
+    TOP["loop top: destructure state<br/>(messages, toolUseContext, ...)"] --> RED
+
+    subgraph RED["Context reduction (before the call)"]
+        R1["applyToolResultBudget<br/>(cap aggregate tool-output size) — :379"]
+        R2["snipCompactIfNeeded — :401"]
+        R3["microcompact — :414"]
+        R4["context-collapse — :440"]
+        R5["autocompact — :454"]
+        R1 --> R2 --> R3 --> R4 --> R5
+    end
+
+    RED --> GUARD["blocking-limit guard<br/>(if auto-compact off) — :641"]
+    GUARD --> CALL["deps.callModel(...) — :659<br/>prependUserContext + fullSystemPrompt<br/>+ tools + thinkingConfig + taskBudget"]
+
+    subgraph STREAM["consume stream — :708"]
+        S1["assistant text/thinking → yield"]
+        S2["tool_use block → collect,<br/>needsFollowUp=true,<br/>StreamingToolExecutor.addTool"]
+    end
+    CALL --> STREAM
+
+    STREAM --> ERR{stream error?}
+    ERR -->|FallbackTriggeredError| FB["switch to fallbackModel,<br/>retry whole request — :894"]
+    FB --> CALL
+    ERR -->|other| EMIT["emit synthetic error<br/>+ missing tool_results — :955"]
+    EMIT --> RETURN1([return: model_error])
+
+    STREAM --> ABORT{aborted?}
+    ABORT -->|yes| RETURN2([drain executor,<br/>return: aborted — :1015])
+
+    ABORT -->|no| FOLLOW{needsFollowUp?}
+    FOLLOW -->|no| RECOVER["withheld-error recovery:<br/>413 → collapse/reactive-compact<br/>max_tokens → escalate/retry — :1062"]
+    RECOVER --> STOP["stop-hooks — :1267<br/>token-budget — :1308"]
+    STOP --> RETURN3([return: completed])
+
+    FOLLOW -->|yes| EXEC["runTools / StreamingToolExecutor — :1380"]
+    EXEC --> ATTACH["append attachments,<br/>queued commands, memory/skill<br/>prefetch results — :1580"]
+    ATTACH --> NEXT["state = next:<br/>messages + assistant + toolResults — :1714"]
+    NEXT --> TOP
+```
+
+### 1. Reduce context (lines 365–468)
+Before every call, the message array is shrunk to fit the window by a stack of reducers,
+run in order: **tool-result budget → snip → microcompact → context-collapse → autocompact**.
+Most are feature-gated. Details and rationale in [03 — Context & Prompts](03-context-and-prompts.md).
+
+### 2. Assemble + call the model (lines 659–708)
+```ts
+for await (const message of deps.callModel({
+  messages: prependUserContext(messagesForQuery, userContext), // history + CLAUDE.md/date
+  systemPrompt: fullSystemPrompt,                               // prompt + git status
+  thinkingConfig, tools, signal,
+  options: { model: currentModel, querySource, taskBudget, fallbackModel, ... },
+}))
+```
+`deps.callModel` is `queryModelWithStreaming` (wired in `src/query/deps.ts:36`), which calls
+the Anthropic SDK's streaming `messages.create`. The `deps` indirection exists so tests can
+inject a fake model without module-level spying (`src/query/deps.ts:21`).
+
+### 3. Consume the stream (lines 708–863)
+Each streamed `AssistantMessage` is pushed to `assistantMessages` and `yield`ed to the UI.
+Any `tool_use` content block is collected into `toolUseBlocks` and flips `needsFollowUp = true`
+(lines 826–835). Crucially, tools begin executing **while the model is still streaming** via the
+`StreamingToolExecutor` (line 841) — a read-only tool can finish before the response closes.
+
+### 4. Branch (line 1062)
+- **`needsFollowUp === false`** → the model is done talking. Run recovery checks for any
+  *withheld* errors, then stop-hooks and the token-budget check, then `return { reason: 'completed' }`.
+- **`needsFollowUp === true`** → execute the tools (line 1380), gather `tool_result`s, append
+  everything to the next state (line 1714), and loop.
+
+### 5. The agentic append (line 1714)
+```ts
+const next: State = {
+  messages: [...messagesForQuery, ...assistantMessages, ...toolResults],
+  ...
+}
+state = next   // continue the while(true)
+```
+This single line — "append the assistant turn and its tool results to history, then loop" — **is** the agent.
+
+---
+
+## Streaming tool execution
+
+There are two execution paths, chosen by a feature gate (`config.gates.streamingToolExecution`):
+
+- **`StreamingToolExecutor`** (`src/services/tools/StreamingToolExecutor.ts`) — tools are queued
+  as their `tool_use` blocks arrive *during* streaming. Concurrency-safe tools run in parallel;
+  a non-concurrency-safe tool gets exclusive access. Results are surfaced in arrival order.
+- **`runTools`** (`src/services/tools/toolOrchestration.ts`) — the batch path: partition the
+  collected `tool_use` blocks into runs of consecutive concurrency-safe tools, execute, yield
+  `{ message, newContext }` updates.
+
+Either way, each tool goes through: **validate input (Zod) → `canUseTool` (permissions) →
+PreToolUse hooks → `tool.call()` → serialize result into a `tool_result`**. See
+[04 — Tools](04-tools.md) and [06 — Permissions](06-permissions.md).
+
+---
+
+## Recovery paths (why the loop is 1,700 lines, not 100)
+
+The happy path is short. Most of `query.ts` is *not losing the turn* when the API misbehaves.
+Each of these `continue`s the loop with adjusted state instead of throwing:
+
+```mermaid
+flowchart TD
+    CALL["model call"] --> OUT{outcome}
+    OUT -->|"overloaded (529x3)"| MF["Model fallback — :894<br/>switch model, strip thinking sigs, retry"]
+    OUT -->|"prompt too long (413)"| PTL["Withhold error → :1085<br/>1) context-collapse drain<br/>2) reactive compact<br/>else surface + return"]
+    OUT -->|"max_output_tokens cut"| MOT["Withhold → :1188<br/>escalate cap 8k to 64k, or<br/>inject 'resume mid-thought' nudge (x3)"]
+    OUT -->|"media too large"| MED["reactive compact strip-retry — :1119"]
+    OUT -->|"stop-hook blocks"| SH["inject blocking feedback,<br/>loop again — :1282"]
+    OUT -->|"token budget left"| TB["auto-continue nudge — :1308"]
+    MF --> CALL
+    PTL --> CALL
+    MOT --> CALL
+    MED --> CALL
+    SH --> CALL
+    TB --> CALL
+```
+
+| Mechanism | Trigger | What it does | Line |
+|---|---|---|---|
+| **Model fallback** | 3 consecutive `529` (overloaded) + `fallbackModel` set | Switch model mid-turn, strip model-bound thinking signatures, retry the request | 894 |
+| **413 recovery** | Prompt-too-long error (withheld from UI) | Try context-collapse drain, then reactive compact, then surface | 1085 |
+| **max_output_tokens recovery** | Response was cut off | Escalate the output cap once (8k→64k), else inject a "resume mid-thought" meta-message and re-run, up to 3× | 1188 |
+| **Media recovery** | Image/PDF too large | Reactive compact strips media and retries | 1119 |
+| **Stop-hook blocking** | A stop-hook returns a blocking error | Append the feedback and loop again (so "keep going until X" hooks work) | 1282 |
+| **Token-budget continuation** | User gave a large output budget (`+500k`-style) and it's not exhausted | Append a nudge and continue automatically | 1308 |
+
+A recurring subtlety: recoverable errors (413, max_output_tokens, media) are **withheld** from
+the yielded stream (lines 799–822) so SDK consumers that terminate on any `error` field don't
+kill the session while recovery is still running. They're only surfaced if recovery is exhausted.
+
+---
+
+## `QueryEngine.ts` vs `query.ts`
+
+Don't be misled by the README: `src/QueryEngine.ts` (~1,300 lines) is a **higher-level,
+SDK-facing wrapper** — it sets up `QueryParams`, threads SDK message types, manages usage
+accumulation, and ultimately drives `query()`. The actual agentic loop is `query.ts`. When you
+want to understand "how the model is called," read `query.ts`.
+
+---
+
+## maxTurns, abort, and subagents
+
+- **`maxTurns`** — optional cap; when exceeded, a `max_turns_reached` attachment is emitted and
+  the loop returns `{ reason: 'max_turns' }` (lines 1705, 1508).
+- **Abort** — `toolUseContext.abortController.signal` (Ctrl+C). On abort mid-stream or mid-tool,
+  the loop drains the `StreamingToolExecutor` to synthesize `tool_result`s for in-flight tools
+  (so no `tool_use` is left without a matching result), then returns an `aborted_*` reason.
+- **Subagents** — when `query()` runs for a sub-agent, `toolUseContext.agentId` is set and
+  `queryTracking.depth` increments. Many behaviors (tool-use summaries, task summaries, main-thread
+  queue draining) are gated on `!agentId`. See [09 — Agents](09-agents-coordinator-tasks.md).
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `query()` | `query.ts:219` | Public async generator; wraps `queryLoop`, fires command-lifecycle completion. |
+| `queryLoop()` | `query.ts:241` | The `while(true)` agentic loop. |
+| `QueryParams` | `query.ts:181` | Inputs: messages, systemPrompt, userContext, systemContext, canUseTool, toolUseContext, fallbackModel, querySource, taskBudget, deps. |
+| `State` | `query.ts:204` | Mutable cross-iteration state. |
+| `deps.callModel` | `query/deps.ts:36` | `= queryModelWithStreaming`; the seam for the actual API call. |
+| `runTools` / `StreamingToolExecutor` | `services/tools/` | The two tool-execution paths. |
+| `handleStopHooks` | `query/stopHooks.ts` | Stop-hook evaluation at turn end. |
+| `checkTokenBudget` | `query/tokenBudget.ts` | The `+500k` auto-continue decision. |

--- a/docs/internals/03-context-and-prompts.md
+++ b/docs/internals/03-context-and-prompts.md
@@ -1,0 +1,154 @@
+# 03 — Context & Prompts
+
+> How the request to the model is composed: the system prompt, the per-conversation context,
+> prompt caching, and the five-layer compaction stack that delivers "unlimited context."
+
+← [02 — The Query Loop](02-query-loop.md) · [Index](README.md) · Next → [04 — Tools](04-tools.md)
+
+---
+
+## The three text inputs to every request
+
+```mermaid
+flowchart TB
+    subgraph SYS["system (cacheable prefix to dynamic suffix)"]
+        DP["Default Claude Code prompt<br/>constants/prompts.ts"]
+        BOUND["__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__<br/>prompts.ts:114"]
+        GIT["git status block<br/>context.ts:116 getSystemContext"]
+        DP --> BOUND --> GIT
+    end
+    subgraph USER["prepended to messages"]
+        CMD["CLAUDE.md / memory files"]
+        DATE["Today's date"]
+    end
+    HIST["conversation history<br/>(user, assistant, tool_use, tool_result)"]
+    SYS --> REQ["Messages request"]
+    USER --> REQ
+    HIST --> REQ
+```
+
+| Input | Built by | Contents |
+|---|---|---|
+| **System prompt** | `buildEffectiveSystemPrompt` (`utils/systemPrompt.ts:41`) | The default prompt, or an agent/coordinator/custom prompt, plus any `--append-system-prompt`. |
+| **System context** | `getSystemContext` (`context.ts:116`) | Git status: branch, default branch, `git status --short`, last 5 commits, git user. Appended *to the system prompt* at `query.ts:449`. |
+| **User context** | `getUserContext` (`context.ts:155`) | `CLAUDE.md` + nested memory files, and today's date. *Prepended to the messages* at `query.ts:660`. |
+
+Both `getSystemContext` and `getUserContext` are **memoized for the conversation** — git status and CLAUDE.md are read once and cached, not re-shelled every turn.
+
+---
+
+## The default system prompt
+
+The text that defines Claude Code's behavior lives in `src/constants/prompts.ts`. It is
+assembled from sections (each a small function returning a string), composed via
+`systemPromptSection` / `resolveSystemPromptSections`. Notable sections:
+
+- **Intro** (`getSimpleIntroSection`, ~:175) — "You are an interactive agent that helps users with software engineering tasks…", plus the cyber-risk instruction and the "never guess URLs" rule.
+- **`# System`** (`getSimpleSystemSection`, ~:186) — the rules about permission modes, `<system-reminder>` tags, prompt-injection flagging, hooks, and automatic context compression.
+- **Hooks** (`getHooksSection`, :127), **system reminders** (:131), **language** (:142), **output style** (:151), **MCP instructions** (:160).
+- **Model identity** — `FRONTIER_MODEL_NAME = 'Claude Opus 4.6'` (:118) and the model-ID table (:121).
+
+### Prompt priority (which prompt wins)
+`buildEffectiveSystemPrompt` (`utils/systemPrompt.ts:41`) resolves in this order:
+
+```mermaid
+flowchart TD
+    O{overrideSystemPrompt set?} -->|yes| USE_O["use override only<br/>(e.g. loop mode)"]
+    O -->|no| C{coordinator mode?}
+    C -->|yes| USE_C["coordinator prompt + append"]
+    C -->|no| A{agent definition?}
+    A -->|"yes (proactive)"| USE_AP["default + agent instructions appended"]
+    A -->|"yes (normal)"| USE_A["agent prompt REPLACES default"]
+    A -->|no| CU{--system-prompt set?}
+    CU -->|yes| USE_CU["custom prompt"]
+    CU -->|no| USE_D["default Claude Code prompt"]
+```
+
+`--append-system-prompt` is always tacked on at the end (except when an override is set).
+
+---
+
+## Prompt caching — the constraint that shapes everything
+
+Anthropic's prompt cache rewards byte-identical request prefixes. Claude Code is engineered
+around this. The marker `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` (`constants/prompts.ts:114`) splits
+the system prompt into:
+
+- **Static prefix** (before the marker) — cross-session/org cacheable; can use `scope: 'global'`.
+- **Dynamic suffix** (after the marker) — session/user-specific (git status, injected memory).
+
+`getCacheControl()` (`services/api/claude.ts:358`) decides where `cache_control: { type: 'ephemeral', ttl?, scope? }` breakpoints go. Consequences seen throughout the code:
+
+- **Tools are sorted deterministically** within partitions (built-in, then MCP) so adding/removing an MCP tool mid-session doesn't bust the cache (see [04 — Tools](04-tools.md)).
+- **Zod schemas are referentially stable** per session (`lazySchema`) so the serialized tool block doesn't change byte-for-byte.
+- **Fork sub-agents reuse the parent's *rendered* system prompt bytes** (`Tool.ts:299` `renderedSystemPrompt`) instead of recomputing it — recomputation could diverge if a GrowthBook flag flipped cold→warm. See [09 — Agents](09-agents-coordinator-tasks.md).
+- **Global cache scope** requires first-party API and *no* MCP tools (per-user dynamic tools can't be shared across users).
+
+If you change anything in the static prefix, you pay full input-token price on the next call. That's why so much code goes out of its way to keep the prefix stable.
+
+---
+
+## The five-layer compaction stack
+
+The system prompt promises "unlimited context through automatic summarization." That promise
+is kept by five reducers run before each model call (in `query.ts`, in this order):
+
+```mermaid
+flowchart LR
+    H["full history"] --> B["1. tool-result budget<br/>:379"]
+    B --> S["2. snip<br/>:401"]
+    S --> M["3. microcompact<br/>:414"]
+    M --> C["4. context-collapse<br/>:440"]
+    C --> A["5. autocompact<br/>:454"]
+    A --> R["request-ready messages"]
+```
+
+| # | Strategy | Trigger | What it does | Feature gate |
+|---|---|---|---|---|
+| 1 | **Tool-result budget** (`applyToolResultBudget`, `utils/toolResultStorage.ts`) | Aggregate tool output exceeds a per-message budget | Replaces oversized old tool outputs with pointers; persists the replacement records for resume | always (no-op if state unset) |
+| 2 | **Snip** (`services/compact/snipCompact.ts`) | History has low-value spans | Drops them; reports `tokensFreed` so autocompact's threshold accounts for it | `HISTORY_SNIP` |
+| 3 | **Microcompact** (`services/compact/microCompact.ts`) | Old, compactable tool calls present | Surgically clears old tool *result content* (FileRead, Bash, Grep, Glob, WebFetch/Search, Edit, Write) by `tool_use_id`; cache-aware variant stores deletions as cache-edits | always / `CACHED_MICROCOMPACT` |
+| 4 | **Context-collapse** (`services/contextCollapse/`) | Near the limit | Projects a "collapsed view" by summarizing spans, keeping a replayable commit log so collapses persist across turns | `CONTEXT_COLLAPSE` |
+| 5 | **Autocompact** (`services/compact/autoCompact.ts` → `compact.ts`) | Token count crosses the threshold (with a buffer below the hard window) | The big one: spawns a **forked summarization query** that reads the whole conversation and writes a structured summary; the turn continues from that summary | always (unless disabled) |
+
+### How autocompact's "summary sub-query" works
+`compactConversation()` (`services/compact/compact.ts`) calls `queryModelWithStreaming()` — the
+*same* API path as a normal turn — with the conversation plus a "summarize this" prompt and no
+tools. The model writes a structured summary (Primary request & intent, key technical concepts,
+files & code touched, errors & fixes, pending tasks, current work verbatim, optional next step).
+That summary becomes a compact-boundary message; subsequent turns read history *after* the
+boundary (`getMessagesAfterCompactBoundary`). This is literally Claude summarizing its own
+conversation so the loop can keep going past the context window.
+
+### Reactive vs. proactive
+Layers 1–5 run *proactively* (before the call). If a call still returns **413 prompt-too-long**,
+the loop falls into *reactive* recovery (`query.ts:1085`): drain staged collapses, then
+`reactiveCompact.tryReactiveCompact()`, then surface the error if nothing worked. See
+[02 — The Query Loop](02-query-loop.md#recovery-paths-why-the-loop-is-1700-lines-not-100).
+
+---
+
+## Attachments & prefetch (extra context injected mid-turn)
+
+After tools run, `getAttachmentMessages` (`utils/attachments.ts`) injects additional context as
+`attachment` messages before the next iteration: edited-file diffs, queued user/command messages,
+and the results of two background prefetches kicked off earlier in the turn:
+
+- **Memory prefetch** (`startRelevantMemoryPrefetch`) — relevant memory files surfaced while the model streams.
+- **Skill-discovery prefetch** (`services/skillSearch/prefetch.ts`, `EXPERIMENTAL_SKILL_SEARCH`) — candidate skills discovered in the background.
+
+Both are awaited *non-blocking* (polled for `settledAt`) so they hide under the model's streaming latency instead of adding to it.
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `buildEffectiveSystemPrompt` | `utils/systemPrompt.ts:41` | Resolve which system prompt to use (override/coordinator/agent/custom/default). |
+| `getSystemContext` | `context.ts:116` | Memoized git-status block appended to the system prompt. |
+| `getUserContext` | `context.ts:155` | Memoized CLAUDE.md + date prepended to messages. |
+| `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` | `constants/prompts.ts:114` | Static/dynamic cache split marker. |
+| `getCacheControl` | `services/api/claude.ts:358` | Places `cache_control` breakpoints. |
+| `compactConversation` | `services/compact/compact.ts` | The forked summarization query (autocompact/reactive). |
+| `getMessagesAfterCompactBoundary` | `utils/messages.ts` | Reads history after the latest compact boundary. |

--- a/docs/internals/04-tools.md
+++ b/docs/internals/04-tools.md
@@ -1,0 +1,180 @@
+# 04 — Tool System
+
+> Every capability the model can invoke is a "tool." This doc covers the `Tool` contract,
+> how the active catalog is built, how a Zod schema becomes what the model sees, how tools
+> execute (and run in parallel), and deferred/searchable tools.
+
+← [03 — Context & Prompts](03-context-and-prompts.md) · [Index](README.md) · Next → [05 — Commands](05-commands.md)
+
+---
+
+## The `Tool` contract
+
+A tool is an object implementing the `Tool<Input, Output>` type (`src/Tool.ts:362`). The model
+only ever sees its name, description, and input schema; everything else is local machinery.
+
+```ts
+type Tool<Input, Output> = {
+  call(args, context, canUseTool, parentMessage, onProgress): Promise<ToolResult<Output>> // :379
+  description(input, options): Promise<string>                                            // :386
+  readonly inputSchema: Input            // Zod schema -> JSON Schema for the model          // :394
+  readonly inputJSONSchema?: ...         // MCP tools provide JSON Schema directly           // :397
+  isConcurrencySafe(input): boolean      // can run in parallel with other tools             // :402
+  isEnabled(): boolean                   // gate on/off (feature flags, env, user type)       // :403
+  isReadOnly(input): boolean             // read vs. mutate                                   // :404
+  isDestructive?(input): boolean         // irreversible (delete/overwrite/send)              // :405
+  interruptBehavior?(): 'cancel'|'block' // what a new user message does mid-run              // :416
+  searchHint?: string                    // keyword hint for ToolSearch (deferred tools)      // :378
+  aliases?: string[]                     // backwards-compatible renames                      // :371
+  // ...isSearchOrReadCommand, inputsEquivalent, outputSchema, backfillObservableInput, etc.
+}
+```
+
+`ToolResult<T>` (`Tool.ts:321`) carries `{ data, newMessages?, contextModifier?, mcpMeta? }` — a
+tool can emit extra messages and (if not concurrency-safe) mutate the `ToolUseContext` for
+subsequent tools. Tools are built via a `buildTool()` helper that spreads sensible defaults over
+a partial definition, so most tools only specify what differs.
+
+### `ToolUseContext` — the runtime backpack
+`ToolUseContext` (`Tool.ts:158`) is the big object threaded through the whole loop and passed into
+every `call()`. It carries the active `options.tools`, the app-state accessor (`getAppState`),
+the abort controller, the message history, permission context, agent identity (`agentId`),
+file-read state, query tracking, and dozens of UI/callback hooks. It's how a tool reaches the
+rest of the system without imports.
+
+---
+
+## Building the active catalog
+
+```mermaid
+flowchart TD
+    BASE["getAllBaseTools()<br/>exhaustive list, feature/user-type gated"] --> FILTER["getTools()<br/>apply deny-rules, mode filters (CLAUDE_CODE_SIMPLE),<br/>REPL-mode hiding"]
+    FILTER --> POOL["assembleToolPool()<br/>merge built-in + MCP tools,<br/>sort within partitions, dedupe by name"]
+    POOL --> CATALOG["active tool list -> toolUseContext.options.tools -> API request"]
+```
+
+- **`getAllBaseTools()`** (`tools.ts:193`) — the full built-in list, respecting feature flags and
+  ant-only gates, and conditionals (e.g. `GlobTool` omitted when native ripgrep search is available,
+  `ToolSearchTool` only when deferred loading is on).
+- **`getTools()`** (`tools.ts:271`) — applies permission deny-rules and mode filters.
+- **`assembleToolPool()`** (`tools.ts:345`) — merges built-in + MCP tools, **sorts alphabetically
+  within each partition**, and dedupes by name (built-ins win). The deterministic order is a
+  prompt-cache stability requirement (see [03 — Prompt caching](03-context-and-prompts.md#prompt-caching--the-constraint-that-shapes-everything)).
+
+The catalog can change between turns; `query.ts` calls `options.refreshTools()` so newly-connected
+MCP servers' tools appear mid-conversation (`query.ts:1660`).
+
+---
+
+## Schema → what the model sees
+
+```mermaid
+flowchart LR
+    ZOD["tool.inputSchema (Zod)"] --> LAZY["lazySchema()<br/>stable reference per session"]
+    LAZY --> CONV["zodToJsonSchema()<br/>cached by WeakMap identity"]
+    CONV --> DEF["BetaTool definition<br/>(name, description, input_schema)"]
+    DEF --> API["sent in the request tools[]"]
+    MCPJSON["MCP tool.inputJSONSchema"] -.->|used directly| DEF
+```
+
+`toolToAPISchema()` (`utils/api.ts`) serializes each tool; `zodToJsonSchema()` converts the Zod
+schema to JSON Schema and caches by identity (so it isn't recomputed every turn, and so the bytes
+stay stable for caching). MCP tools skip Zod and provide `inputJSONSchema` directly.
+
+---
+
+## Execution & concurrency
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Loop as query.ts
+    participant Exec as runTools / StreamingToolExecutor
+    participant Perm as canUseTool
+    participant Hook as PreToolUse hooks
+    participant Tool as tool.call()
+
+    Loop->>Exec: tool_use blocks
+    Note over Exec: partition by isConcurrencySafe(input)<br/>safe -> parallel batch; unsafe -> exclusive
+    loop per tool
+        Exec->>Exec: validate input (Zod inputSchema)
+        Exec->>Perm: can this run? (mode + rules + classifier)
+        Perm-->>Exec: allow / deny / ask
+        Exec->>Hook: PreToolUse (may allow/deny/modify input)
+        Hook-->>Exec: decision
+        Exec->>Tool: call(args, context, ...)
+        Tool-->>Exec: ToolResult { data, newMessages?, contextModifier? }
+        Exec-->>Loop: tool_result message (+ newContext)
+    end
+```
+
+- **Concurrency** is driven by `isConcurrencySafe(input)` (default `false`, conservative). The
+  executor groups consecutive safe tools to run in parallel; an unsafe tool gets exclusive access
+  and may return a `contextModifier` that mutates `ToolUseContext` for following tools.
+- **`isReadOnly` / `isDestructive`** feed both scheduling and permissions. For example `BashTool`
+  sets `isConcurrencySafe === isReadOnly`, and `isReadOnly` only returns true for pure-read commands
+  (no `cd`, no mutations) — so two `grep`s parallelize but `rm` does not.
+- See [02 — Streaming tool execution](02-query-loop.md#streaming-tool-execution) for the two
+  execution paths and [06 — Permissions](06-permissions.md) for the `canUseTool` pipeline.
+
+---
+
+## Deferred tools & ToolSearch
+
+When the tool catalog is large (many MCP tools), sending every schema up front wastes context.
+Tools can set `shouldDefer: true` and are advertised with `defer_loading: true`. The
+**`ToolSearchTool`** (`tools/ToolSearchTool/`) lets the model find a deferred tool by keyword
+(`searchHint` matching) or by exact name (`select:ToolName`) — its schema is then loaded on
+demand. Enabled via `ENABLE_TOOL_SEARCH` (e.g. `auto`, `auto:N%`), typically when MCP tool
+descriptions would exceed ~10% of the context window. (You can see this in the live tool list as
+deferred tools that must be fetched before use.)
+
+---
+
+## The tool inventory (~39)
+
+| Category | Tools |
+|---|---|
+| **File I/O** | `FileReadTool`, `FileWriteTool`, `FileEditTool`, `NotebookEditTool` |
+| **Search** | `GlobTool`, `GrepTool`, `WebSearchTool`, `WebFetchTool` |
+| **Execution** | `BashTool`, `PowerShellTool`, `REPLTool`, `SkillTool` |
+| **Agents & teams** | `AgentTool`, `SendMessageTool`, `TeamCreateTool`, `TeamDeleteTool` |
+| **Tasks (v2)** | `TaskCreateTool`, `TaskGetTool`, `TaskUpdateTool`, `TaskListTool`, `TaskStopTool`, `TaskOutputTool` |
+| **Mode & state** | `EnterPlanModeTool`, `ExitPlanModeTool`, `EnterWorktreeTool`, `ExitWorktreeTool`, `TodoWriteTool` |
+| **MCP** | `MCPTool`, `McpAuthTool`, `ListMcpResourcesTool`, `ReadMcpResourceTool` |
+| **Discovery / meta** | `ToolSearchTool`, `AskUserQuestionTool`, `ConfigTool`, `LSPTool` |
+| **Scheduling / async** | `ScheduleCronTool` (`CronCreate`), `RemoteTriggerTool`, `SleepTool`, `SyntheticOutputTool` |
+| **Proactive / ant-only** | `BriefTool`, `MonitorTool`, `TungstenTool`, plus testing tools under `tools/testing/` |
+
+(Exact set is feature-flag- and user-type-dependent; this is the on-disk catalog.)
+
+---
+
+## Anatomy of a tool directory
+
+Tools live in `src/tools/<Name>/`. Typical files:
+
+| File | Purpose |
+|---|---|
+| `<Name>.ts` / `<Name>.tsx` | The tool definition (`buildTool({ call, isReadOnly, ... })`). |
+| `prompt.ts` | The tool's description text sent to the model. |
+| `constants.ts` | Tool name + constants. |
+| `types.ts` | Zod input schema + types. |
+| `UI.tsx` | How the tool's invocation/result renders in the terminal. |
+| (extras) | e.g. `BashTool/` has `bashPermissions.ts`, `readOnlyValidation.ts`, `commandSemantics.ts`. |
+
+`AgentTool/` is the heaviest (it spawns nested `query()` loops — see [09 — Agents](09-agents-coordinator-tasks.md)).
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `Tool<Input,Output>` | `Tool.ts:362` | The tool contract. |
+| `ToolUseContext` | `Tool.ts:158` | Runtime context threaded into every tool. |
+| `getAllBaseTools` / `getTools` / `assembleToolPool` | `tools.ts:193/271/345` | Build the active catalog. |
+| `findToolByName` / `toolMatchesName` | `Tool.ts:358/348` | Look up a tool by name or alias. |
+| `runTools` | `services/tools/toolOrchestration.ts` | Batch execution path. |
+| `StreamingToolExecutor` | `services/tools/StreamingToolExecutor.ts` | Stream-as-you-go execution path. |
+| `zodToJsonSchema` / `toolToAPISchema` | `utils/zodToJsonSchema.ts`, `utils/api.ts` | Schema → API serialization (cached). |

--- a/docs/internals/05-commands.md
+++ b/docs/internals/05-commands.md
@@ -1,0 +1,145 @@
+# 05 — Command System
+
+> Slash commands (`/commit`, `/review`, `/cost`, `/doctor`, …): the three command types,
+> how a typed `/foo` is parsed and dispatched, and how prompt-commands feed the query loop.
+
+← [04 — Tools](04-tools.md) · [Index](README.md) · Next → [06 — Permissions](06-permissions.md)
+
+---
+
+## Three kinds of command
+
+`Command` (`src/types/command.ts:205`) is a discriminated union over `type`:
+
+```mermaid
+flowchart TD
+    CMD["Command (CommandBase: name, description, isEnabled, aliases, source, hooks)"]
+    CMD --> P["type: 'prompt' - PromptCommand<br/>getPromptForCommand() -> ContentBlockParam[]<br/>sent to the LLM with allowedTools[]"]
+    CMD --> L["type: 'local' - LocalCommand<br/>call() -> text | compact | skip<br/>runs in-process, no model call"]
+    CMD --> J["type: 'local-jsx' - LocalJSXCommand<br/>call(onDone) -> React JSX<br/>renders UI in the REPL"]
+```
+
+| Type | Returns | Touches the model? | Examples |
+|---|---|---|---|
+| **PromptCommand** | `ContentBlockParam[]` from `getPromptForCommand(args, ctx)` | **Yes** — its output becomes a user message + `allowedTools` and triggers a query | `/commit`, `/review` |
+| **LocalCommand** | `LocalCommandResult` (`text` \| `compact` \| `skip`) | No — pure in-process | `/cost`, `/version` |
+| **LocalJSXCommand** | React JSX + an `onDone()` callback | No (renders UI; `onDone` may then trigger a query) | `/doctor`, `/install` |
+
+All three extend `CommandBase` (name, description, `isEnabled`, aliases, `source`, optional hooks).
+
+---
+
+## Registry & registration
+
+`src/commands.ts` assembles the command list:
+
+- **Built-ins** — ~80 statically imported commands, with feature-gated imports for conditional
+  ones (`PROACTIVE`, `KAIROS`, `BRIDGE_MODE`, `WORKFLOW_SCRIPTS`, …). Internal-only commands are
+  filtered from external builds.
+- **Dynamic sources** — `loadAllCommands()` merges in: bundled skills, built-in plugin skills,
+  user skill directories (`.claude/skills/`), workflow commands, plugin commands, plugin skills,
+  and MCP prompts.
+- **Availability gating** — `meetsAvailabilityRequirement()` filters by surface
+  (`claude-ai` / `console`) before `isEnabled()` runs. `getCommands()` is the memoized entry point.
+
+```mermaid
+flowchart LR
+    BUILTIN["~80 built-in commands<br/>(feature-gated imports)"] --> ALL
+    SKILLS["skills (bundled, user dirs, plugins)"] --> ALL
+    WF["workflow commands"] --> ALL
+    MCP["MCP prompts -> mcp__server__prompt"] --> ALL
+    ALL["loadAllCommands() (memoized)"] --> AVAIL["meetsAvailabilityRequirement + isEnabled"]
+    AVAIL --> REG["getCommands() -> active registry"]
+```
+
+---
+
+## Dispatch flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant REPL
+    participant Parse as parseSlashCommand()
+    participant Disp as processSlashCommand()
+    participant Route as getMessagesForSlashCommand()
+    participant Q as query.ts
+
+    REPL->>Parse: "/commit some message"
+    Parse-->>Disp: { commandName: 'commit', args, isMcp }
+    Disp->>Disp: hasCommand('commit')?
+    Disp->>Route: route by command.type
+    alt local-jsx
+        Route->>Route: load module, call(onDone), render JSX
+    else local
+        Route->>Route: load module, call(args) -> text/compact/skip
+    else prompt
+        Route->>Route: getPromptForCommand(args) -> ContentBlockParam[]
+        Route-->>REPL: user message + allowedTools + shouldQuery:true
+        REPL->>Q: query(messages with prompt, tools=allowedTools)
+    end
+```
+
+1. **`parseSlashCommand()`** (`slashCommandParsing.ts`) — regex-splits `/<name> <args>` and flags MCP commands.
+2. **`processSlashCommand()`** (`processSlashCommand.tsx`) — validates the command exists and routes by type.
+3. **`getMessagesForSlashCommand()`** — type switch:
+   - **local-jsx**: lazy-load, `call(onDone, ctx, args)`, render JSX, await `onDone`.
+   - **local**: lazy-load, `call(args, ctx)`, handle the result union.
+   - **prompt**: `getPromptForCommand()` → wrap as a user message + inject `allowedTools` + set `shouldQuery: true`.
+
+Slash commands are processed **after** the turn (not sent as raw text mid-turn) — the query loop
+explicitly excludes them from its mid-turn queue drain (`query.ts:1573`).
+
+### PromptCommand → LLM
+For `/commit`, `getPromptForCommand()` returns markdown instructions, often with embedded shell
+output (e.g. `git status`/`git diff` captured at expansion time), and sets a restricted tool
+allow-list like `['Bash(git add:*)', 'Bash(git commit:*)']`. That becomes a user message, the
+allowed tools enter the `ToolUseContext`, and `query()` runs as normal — the model sees the
+instructions, calls the permitted git tools, and reports back.
+
+### Forked commands
+A PromptCommand with `context: 'fork'` runs in an **isolated sub-agent** with its own token budget
+(`executeForkedSlashCommand` → `runAgent`). In assistant/proactive mode this can be fire-and-forget,
+with the result re-enqueued as a meta prompt. See [09 — Agents](09-agents-coordinator-tasks.md).
+
+---
+
+## Skill-backed commands
+
+Skills (markdown files with frontmatter) become commands too:
+
+- **`getSkillToolCommands()`** (`commands.ts`) — all prompt-commands the *model* may invoke via
+  the `SkillTool` (everything not `disableModelInvocation`).
+- **`getSlashCommandToolSkills()`** (used in `query.ts:22`) — the subset surfaced in `/skills`.
+- User skills load from `.claude/skills/`, `~/.claude/skills/`, and policy dirs; conditional skills
+  can activate when certain file paths are touched. See [12 — Skills](12-plugins-skills-memory.md).
+
+---
+
+## Command inventory (built-ins, by theme)
+
+| Theme | Commands |
+|---|---|
+| Session | `/resume`, `/rewind`, `/clear`, `/exit`, `/help`, `/status`, `/share` |
+| Code | `/commit`, `/review`, `/diff`, `/branch`, `/security-review`, `/pr_comments` |
+| Analysis | `/cost`, `/usage`, `/context`, `/doctor`, `/insights` |
+| Config | `/config`, `/model`, `/theme`, `/vim`, `/keybindings`, `/permissions`, `/hooks`, `/plugin`, `/mcp` |
+| AI features | `/plan`, `/effort`, `/compact`, `/memory`, `/fast`, `/skills`, `/tasks`, `/agents` |
+| Integrations | `/ide`, `/mobile`, `/desktop`, `/chrome` |
+| Feature-gated / ant | `/proactive`, `/brief`, `/assistant`, `/bridge`, `/workflows`, `/buddy`, `/fork`, `/ultraplan`, … |
+
+(~100 entries under `src/commands/`; availability varies by build and surface.)
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `Command` | `types/command.ts:205` | The 3-way union + base. |
+| `getCommands()` | `commands.ts` | Memoized active registry. |
+| `loadAllCommands()` | `commands.ts` | Merge all command sources. |
+| `parseSlashCommand()` | `slashCommandParsing.ts` | Parse `/<name> <args>`. |
+| `processSlashCommand()` | `processSlashCommand.tsx` | Dispatch entry from the REPL. |
+| `getMessagesForSlashCommand()` | `processSlashCommand.tsx` | Route by command type. |
+| `getSkillToolCommands()` / `getSlashCommandToolSkills()` | `commands.ts` | Model-invocable + listed skills. |

--- a/docs/internals/06-permissions.md
+++ b/docs/internals/06-permissions.md
@@ -1,0 +1,147 @@
+# 06 — Permission System
+
+> Before any tool runs, `canUseTool` decides allow / deny / ask. This doc covers the permission
+> modes, the ordered decision pipeline, the rule model, the auto classifier, and hook integration.
+
+← [05 — Commands](05-commands.md) · [Index](README.md) · Next → [07 — Services](07-services-api-auth.md)
+
+---
+
+## Where it sits
+
+Every tool execution in [02 — The Query Loop](02-query-loop.md) passes through a `CanUseToolFn`
+(`src/hooks/useCanUseTool.tsx`). The decision engine is `hasPermissionsToUseTool` →
+`hasPermissionsToUseToolInner` in `src/utils/permissions/permissions.ts`.
+
+```mermaid
+flowchart TD
+    TU["tool_use block"] --> VALID["validate input (Zod)"]
+    VALID --> CUT["canUseTool()"]
+    CUT --> RES{result}
+    RES -->|allow| RUN["tool.call()"]
+    RES -->|deny| SKIP["tool_result: denied (model adapts)"]
+    RES -->|ask| PROMPT["prompt user (or route to IDE/coordinator/hook)"]
+    PROMPT -->|approve| RUN
+    PROMPT -->|reject| SKIP
+```
+
+---
+
+## Permission modes
+
+`PermissionMode` (`src/types/permissions.ts`) — the user-facing modes plus internal ones:
+
+| Mode | Behavior |
+|---|---|
+| **`default`** | Prompt before anything not explicitly allowed. The baseline. |
+| **`acceptEdits`** | Auto-allow edit/write tools inside the working directory; still classify/ask outside it. |
+| **`plan`** | Plan mode — behaves like `default` unless the user *had* `bypassPermissions` available; read-heavy, no writes expected. |
+| **`bypassPermissions`** | Auto-allow everything **except** bypass-immune safety checks (e.g. `.git/`, `.claude/`, shell rc files, cross-machine paths) and explicit ask-rules. Set by `--dangerously-skip-permissions`. |
+| **`dontAsk`** | Convert every `ask` into a hard `deny` (no prompts at all). |
+| **`auto`** *(ant-only, gated)* | A transcript classifier auto-approves safe actions and prompts on uncertain/risky ones. |
+| **`bubble`** *(internal)* | Used internally; not user-addressable. |
+
+---
+
+## The decision pipeline
+
+`hasPermissionsToUseToolInner` evaluates in order; **first match wins**:
+
+```mermaid
+flowchart TD
+    A["1a. tool-level DENY rule?"] -->|yes| D1([deny])
+    A -->|no| B["1b. tool-level ASK rule?<br/>(sandbox auto-allow may bypass)"]
+    B -->|yes| ASK1([ask])
+    B -->|no| C["1c. tool.checkPermissions(input)<br/>(Bash command parse, path safety, ...)"]
+    C -->|deny| D2([deny])
+    C -->|"ask (content-specific)"| ASK2([ask - bypass-immune])
+    C -->|allow/passthrough| E["1g. bypass-immune safety checks<br/>(.git, .claude, shell rc, cross-machine)"]
+    E -->|hit| ASK3([ask])
+    E -->|clear| F{mode}
+    F -->|bypassPermissions / plan+bypass| ALLOW1([allow])
+    F -->|other| G["2b. entire-tool ALWAYS-ALLOW rule?"]
+    G -->|yes| ALLOW2([allow])
+    G -->|no| H["passthrough -> ask"]
+    H --> AUTO{auto mode?}
+    AUTO -->|"yes + ask"| CLS["YOLO classifier<br/>(after safe-tool allowlist + acceptEdits fast-path)"]
+    CLS -->|safe| ALLOW3([allow])
+    CLS -->|risky| ASK4([ask])
+    AUTO -->|no| ASK5([ask -> prompt user])
+```
+
+Two things are **bypass-immune** — they prompt even under `bypassPermissions`/`acceptEdits`:
+content-specific ask-rules returned by a tool's `checkPermissions`, and the hard safety checks for
+sensitive paths. That's a deliberate guardrail: "skip permissions" never means "let me overwrite `.git`."
+
+---
+
+## The rule model
+
+Rules come from multiple **sources**, evaluated with precedence (highest first):
+
+| Source | Where |
+|---|---|
+| `policySettings` | Enterprise/managed settings (read-only, can't be deleted) |
+| `flagSettings` | CLI flags (`--allow`, `--deny`, `--settings`) |
+| `localSettings` | `.claude/settings.local.json` (per-session, gitignored) |
+| `projectSettings` | `.claude/settings.json` (committed) |
+| `userSettings` | `~/.claude/settings.json` |
+| `command` / `session` / `cliArg` | Runtime (`/permissions add …`, ad-hoc, session-scoped) |
+
+Each rule is `{ source, ruleBehavior: 'allow'|'deny'|'ask', ruleValue: { toolName, ruleContent? } }`.
+`ruleContent` lets a rule scope to specific inputs, e.g. `Bash(git commit:*)` matches only git-commit
+bash invocations. Tools implement their own matchers in `checkPermissions` (Bash parses the command
+line; file tools run path-safety checks).
+
+---
+
+## The auto classifier (ant-only)
+
+When `mode === 'auto'` and the base decision is `ask`, instead of prompting, an LLM classifier
+(`classifyYoloAction`, `src/utils/permissions/yoloClassifier.ts`) judges whether the action is safe.
+Guards around it:
+
+- **Safe-tool allowlist** — read-only tools (FileRead, Grep, Glob, LSP, ListMcpResources), task-metadata tools (TodoWrite, Task*), and UI-safe tools (AskUserQuestion, EnterPlanMode, SendMessage) skip the classifier entirely.
+- **acceptEdits fast-path** — if simulating `acceptEdits` would allow it, skip the classifier.
+- **Denial tracking** (`denialTracking.ts`) — after a few consecutive denials (or a session total), fall back to normal prompting to break classifier→deny loops. A successful tool use resets the consecutive counter.
+- **Fail-closed** — if the classifier can't reach the API (non-interactive, overload), it falls back to prompting with a grace period.
+
+```mermaid
+flowchart LR
+    ASK["base decision: ask"] --> SAFE{safe-tool allowlist?}
+    SAFE -->|yes| ALLOW([allow, no classifier])
+    SAFE -->|no| FAST{acceptEdits fast-path allows?}
+    FAST -->|yes| ALLOW
+    FAST -->|no| LIM{denial limit hit?}
+    LIM -->|yes| PROMPT([fall back to user prompt])
+    LIM -->|no| YOLO["classifyYoloAction() (LLM)"]
+    YOLO -->|safe| ALLOW
+    YOLO -->|block| PROMPT
+```
+
+---
+
+## Hook integration
+
+`PermissionRequest` / `PreToolUse` hooks run **after** the mode/rule checks but **before** the user
+prompt. A hook can return `{ behavior: 'allow' | 'deny', updatedInput?, updatedPermissions? }` — so a
+hook can approve, reject, or *rewrite the tool input* before execution. There are several handler
+contexts: interactive (main thread, hooks race the user prompt), coordinator worker, and headless
+agent (hooks resolved synchronously). If no hook decides, the flow proceeds to the UI prompt.
+
+This is how the system-prompt line "treat feedback from hooks as coming from the user" is enforced
+in practice.
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `CanUseToolFn` | `hooks/useCanUseTool.tsx` | The permission function signature passed into `query()` and tools. |
+| `hasPermissionsToUseTool` / `…Inner` | `utils/permissions/permissions.ts` | The decision engine (outer wrapper + ordered pipeline). |
+| `PermissionMode` | `types/permissions.ts` | The mode enum. |
+| `PermissionResult` / `PermissionDecision` | `types/permissions.ts` | `checkPermissions` output (with passthrough) vs. final allow/deny/ask. |
+| `ToolPermissionContext` | `Tool.ts:123` | Immutable mode + rule sets + working dirs, lives on `AppState`. |
+| `classifyYoloAction` | `utils/permissions/yoloClassifier.ts` | The auto-mode LLM classifier. |
+| `DenialTrackingState` | `utils/permissions/denialTracking.ts` | Consecutive/total denial counters + fallback threshold. |

--- a/docs/internals/07-services-api-auth.md
+++ b/docs/internals/07-services-api-auth.md
@@ -1,0 +1,140 @@
+# 07 — Services: API, Auth, Analytics, Cost
+
+> The plumbing under the query loop: how a request reaches the Anthropic API, how retries and
+> model fallback work, how auth (OAuth/keychain/API key) is resolved, how feature flags and
+> telemetry flow through GrowthBook, and how cost is tracked.
+
+← [06 — Permissions](06-permissions.md) · [Index](README.md) · Next → [08 — MCP](08-mcp.md)
+
+---
+
+## The API call path
+
+```mermaid
+flowchart TD
+    Q["query.ts: deps.callModel"] --> QMS["queryModelWithStreaming<br/>services/api/claude.ts:752"]
+    QMS --> VCR["withStreamingVCR (record/replay for tests)"]
+    VCR --> QM["queryModel (assemble params)"]
+    QM --> RETRY["withRetry wrapper<br/>services/api/withRetry.ts"]
+    RETRY --> CLIENT["getAnthropicClient()<br/>services/api/client.ts"]
+    CLIENT --> CREATE["anthropic.beta.messages.create(stream)<br/>claude.ts:864"]
+    CREATE --> LLM["Anthropic API / Bedrock / Vertex / Foundry"]
+    LLM --> STREAMEV["stream events -> AssistantMessage objects -> yield"]
+```
+
+`queryModelWithStreaming` (`services/api/claude.ts:752`) is what `query()` calls. It assembles
+the request (messages, system blocks, tool schemas, thinking config, beta headers, cache control,
+optional `task_budget`), wraps it in `withRetry`, and streams via the Anthropic SDK's
+`beta.messages.create`. A **non-streaming fallback** path (`executeNonStreamingRequest`, claude.ts:818)
+kicks in on certain overload conditions, with `max_tokens` adjusted to fit the window.
+
+The client (`getAnthropicClient`, `services/api/client.ts`) supports four backends selected by env:
+first-party API, **AWS Bedrock**, **GCP Vertex**, **Azure Foundry**. It injects headers (`x-app: cli`,
+session id, a client-request-id for timeout correlation) and a custom `fetch` wrapper.
+
+---
+
+## Retry, fallback, and error handling
+
+```mermaid
+flowchart TD
+    CALL["API call"] --> E{error?}
+    E -->|"408/409/5xx"| BACK["exponential backoff<br/>(500ms base x2, cap ~32s, respect Retry-After)"]
+    E -->|"401/403"| AUTH["clear API-key cache /<br/>refresh OAuth token, retry"]
+    E -->|"429 / 529"| RL["rate-limit / overloaded"]
+    RL --> CNT{consecutive 529 >= 3?}
+    CNT -->|yes, fallbackModel set| FB["throw FallbackTriggeredError<br/>-> query.ts switches model"]
+    CNT -->|no| BACK
+    BACK --> CALL
+    AUTH --> CALL
+    E -->|"413 prompt-too-long / media"| UP["surface to query.ts<br/>reactive-compact recovery"]
+```
+
+`withRetry` (`services/api/withRetry.ts`) is a generator wrapping the call with exponential backoff.
+Key behaviors:
+
+- **Retryable**: `408/409` (timeout/lock), `429/529` (rate/overload), `401/403` (auth — cache cleared + token refresh), `5xx`.
+- **Model fallback**: after `MAX_529_RETRIES` consecutive overloads with a `fallbackModel` configured, it raises `FallbackTriggeredError`, which `query.ts:894` catches to switch models mid-turn.
+- **Source-aware**: only "foreground" query sources (REPL main thread, agents, compact, verification) retry aggressively on 529; background sources (suggestions, etc.) bail fast to avoid amplifying a capacity cascade.
+- **Fast-mode cooldown**: short `retry-after` retries fast-mode; longer ones cool down to a standard-speed model to preserve the prompt cache.
+
+Error → user message mapping lives in `services/api/errors.ts` (`getAssistantMessageFromError`):
+it categorizes (`rate_limit`, `authentication_failed`, `invalid_request`, prompt-too-long, media-size)
+and produces friendly text. Prompt-too-long and media errors are tagged so the reactive-compaction
+recovery in `query.ts` knows what to do (see [03 — Compaction](03-context-and-prompts.md)).
+
+---
+
+## Prompt caching
+
+`getCacheControl()` (`claude.ts:358`) returns the `cache_control` object placed on system/message
+blocks. It decides 1h-TTL eligibility (ant users / subscribers not in overage) and `scope: 'global'`
+eligibility (first-party API + no MCP tools). See the prompt-caching section in
+[03 — Context & Prompts](03-context-and-prompts.md#prompt-caching--the-constraint-that-shapes-everything)
+for why the whole codebase guards prefix stability.
+
+---
+
+## Authentication
+
+```mermaid
+flowchart TD
+    START["resolve auth"] --> OAUTH{subscriber + OAuth token?}
+    OAUTH -->|yes| USEOAUTH["authToken: accessToken"]
+    OAUTH -->|no| KEY{ANTHROPIC_API_KEY?}
+    KEY -->|yes| USEKEY["apiKey: env var"]
+    KEY -->|no| HELPER["apiKeyHelper / keychain / interactive"]
+    USEOAUTH --> CLIENT["Anthropic client"]
+    USEKEY --> CLIENT
+    HELPER --> CLIENT
+```
+
+- **OAuth 2.0 + PKCE** (`services/oauth/`) — `startOAuthFlow()` opens a browser to a local callback,
+  captures the code, exchanges it for `{ accessToken, refreshToken, expiresAt }`. A manual paste-the-code
+  fallback exists for headless environments.
+- **Token storage** — macOS keychain (per-session entry); `handleOAuth401Error()` refreshes on `401`.
+- **API key** — `ANTHROPIC_API_KEY` env var, or an `apiKeyHelper` command, or OS credential manager.
+- **Priority** — OAuth (if subscriber) > env API key > helper/keychain.
+- Cloud backends (Bedrock/Vertex/Foundry) use their own credential chains; auth errors clear the relevant provider cache.
+
+---
+
+## Analytics & feature flags (GrowthBook + OTel)
+
+- **Feature flags** — `getFeatureValue_CACHED_MAY_BE_STALE(name, default)` (`services/analytics/growthbook.ts`)
+  reads a **disk-cached** GrowthBook config (~ms), returning a possibly-stale value rather than blocking
+  on the network. The client is keyed on user/session/org attributes and re-initialized when auth changes.
+  This is distinct from the build-time `feature('X')` flags (see [13 — Build & Flags](13-build-config-flags.md)).
+- **Events** — `logEvent(name, metadata)` (`services/analytics/index.ts`) queues until an analytics sink
+  attaches during init, then fans out to Datadog + a first-party logger. Metadata fields are
+  type-guarded against accidentally logging code/filepaths (the giant `AnalyticsMetadata_I_VERIFIED_…`
+  type name is the enforcement mechanism). PII-tagged fields route to privileged columns.
+- **OpenTelemetry** — metrics/traces via OTel SDK + gRPC; lazy-loaded (heavy) and initialized only
+  after the trust dialog.
+
+---
+
+## Cost tracking
+
+`src/cost-tracker.ts` accumulates per-model usage; `calculateUSDCost(model, usage)`
+(`utils/modelCost.ts`) computes dollars from token counts using per-model pricing tiers, including
+cache-read (≈1/10 input) and cache-write (≈5/4 input) pricing and a fast-mode multiplier for Opus.
+Totals live in the global state singleton (`getTotalCostUSD`, see [01 — Startup](01-startup.md)) and
+surface via `/cost`. Unknown models fall back to a default tier and log a telemetry event.
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `queryModelWithStreaming` | `services/api/claude.ts:752` | The streaming API entry called by `query()`. |
+| `executeNonStreamingRequest` | `services/api/claude.ts:818` | Non-streaming overload fallback. |
+| `getAnthropicClient` | `services/api/client.ts` | Builds the SDK client for the active backend. |
+| `withRetry` | `services/api/withRetry.ts` | Backoff + auth refresh + model fallback. |
+| `FallbackTriggeredError` | `services/api/withRetry.ts` | Signals `query.ts` to switch to `fallbackModel`. |
+| `getAssistantMessageFromError` | `services/api/errors.ts` | API error → user-facing message + category. |
+| `getCacheControl` | `services/api/claude.ts:358` | Cache breakpoint placement. |
+| `getFeatureValue_CACHED_MAY_BE_STALE` | `services/analytics/growthbook.ts` | Disk-cached runtime flag lookup. |
+| `logEvent` | `services/analytics/index.ts` | Telemetry event queue. |
+| `calculateUSDCost` | `utils/modelCost.ts` | Token usage → USD. |

--- a/docs/internals/08-mcp.md
+++ b/docs/internals/08-mcp.md
@@ -1,0 +1,106 @@
+# 08 — MCP Integration
+
+> Model Context Protocol works two ways here: Claude Code as a **client** connecting to external
+> MCP servers, and Claude Code as a **server** exposing its own tools. Plus the repo's separate
+> source-explorer MCP server.
+
+← [07 — Services](07-services-api-auth.md) · [Index](README.md) · Next → [09 — Agents](09-agents-coordinator-tasks.md)
+
+---
+
+## Client: connecting to external MCP servers
+
+```mermaid
+flowchart TD
+    CFG["config: .mcp.json + settings + plugins + managed<br/>getAllMcpConfigs() (merged by precedence)"] --> CONN["connectToServer()<br/>services/mcp/client.ts"]
+    CONN --> T{transport}
+    T -->|stdio| STDIO["spawn subprocess"]
+    T -->|sse| SSE["SSE client"]
+    T -->|http| HTTP["streamable HTTP"]
+    T -->|ws| WS["WebSocket"]
+    T -->|sdk| SDKT["in-process SDK transport"]
+    STDIO --> NEG["negotiate capabilities"]
+    SSE --> NEG
+    HTTP --> NEG
+    WS --> NEG
+    SDKT --> NEG
+    NEG --> DISC["discover: tools/list, resources/list, prompts/list"]
+    DISC --> STATE["appState.mcp = { clients, tools, commands, resources }"]
+    STATE --> CATALOG["tools merged into the active catalog (query.ts:689)"]
+```
+
+- **Config** comes from `.mcp.json`, user/project settings, plugins, and managed/enterprise configs,
+  merged by precedence. Each server config is one of: `stdio`, `sse`, `http`, `ws`, `sdk`, or a
+  `claudeai-proxy` relay.
+- **Connection states**: `connected` · `failed` · `needs-auth` · `pending` · `disabled`
+  (the `MCPServerConnection` union in `services/mcp/types.ts`).
+- **Discovery** calls `tools/list`, `resources/list`, `prompts/list`. Tools are normalized to the
+  name `mcp__<server>__<tool>`, their descriptions capped (~2048 chars) so a verbose OpenAPI-generated
+  server can't blow the context budget, and merged into `appState.mcp.tools`.
+- The tool catalog refreshes between turns (`query.ts:1660` via `options.refreshTools()`), so a server
+  that connects mid-conversation becomes usable without a restart.
+
+### How external capabilities surface
+
+| MCP concept | Becomes | Surfaced via |
+|---|---|---|
+| **Tool** (`tools/list`) | A `Tool` named `mcp__server__tool` in the catalog | `MCPTool` template; `client.callTool()` on invoke |
+| **Resource** (`resources/list`) | Listable/readable content | `ListMcpResourcesTool`, `ReadMcpResourceTool` |
+| **Prompt** (`prompts/list`) | A slash command `/mcp__server__prompt` | command registry (see [05](05-commands.md)) |
+| **Auth needed** | A pseudo-tool `mcp__server__authenticate` | `McpAuthTool` → OAuth flow → reconnect |
+
+`MCPTool` output is capped (~100KB) and binary content is persisted to disk rather than streamed
+into context.
+
+---
+
+## MCP-related tools
+
+| Tool | Purpose |
+|---|---|
+| **`MCPTool`** | Template representing a remote MCP tool call; name/description/schema overridden per server. Routes to `ensureConnectedClient()` → `client.callTool()`. |
+| **`ListMcpResourcesTool`** | Read-only; lists resources across connected servers (optionally filtered by server). |
+| **`ReadMcpResourceTool`** | Read-only; fetches a resource by `{server, uri}`; persists binary blobs. |
+| **`McpAuthTool`** | Surfaced for `needs-auth` servers; runs `performMCPOAuthFlow()`, then reconnects and swaps the auth pseudo-tool for the server's real tools. |
+
+---
+
+## Claude Code as an MCP server
+
+`src/entrypoints/mcp.ts` (`claude mcp serve`) runs Claude Code's own tools behind the MCP protocol
+over stdio: it implements `ListTools` (from `getTools()`) and `CallTool` (executing with a
+`ToolUseContext`), converting Zod schemas to JSON Schema for SDK compliance. This lets *other* MCP
+clients (another Claude Code, Claude Desktop, an IDE) call Claude Code's tools.
+
+```mermaid
+flowchart LR
+    OTHER["any MCP client"] -->|stdio| MCPSRV["entrypoints/mcp.ts"]
+    MCPSRV --> GT["getTools()"]
+    MCPSRV --> EXEC["execute tool with ToolUseContext"]
+```
+
+---
+
+## The source-explorer server (`mcp-server/`, not core)
+
+The repo ships a **separate** MCP server (published to npm as `warrioraashuu-codemaster`) whose only
+job is to let an MCP client browse *this leaked source tree*. It is not part of the Claude Code
+runtime. It exposes tools like `list_tools`, `list_commands`, `get_tool_source`,
+`get_command_source`, `read_source_file`, `search_source`, `list_directory`, `get_architecture`,
+and resources like `claude-code://architecture` and `claude-code://source/{path}`. Transports:
+stdio (default), HTTP, SSE. See [`mcp-server/README.md`](../../mcp-server/README.md).
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `connectToServer` | `services/mcp/client.ts` | Transport factory → `MCPServerConnection`. |
+| `ensureConnectedClient` | `services/mcp/client.ts` | Validate/refresh a connected client before RPC. |
+| `fetchToolsForClient` / `fetchResourcesForClient` | `services/mcp/client.ts` | Cached discovery; populate `appState.mcp`. |
+| `buildMcpToolName` / `mcpInfoFromString` | `services/mcp/mcpStringUtils.ts` | `mcp__server__tool` name encode/decode. |
+| `MCPServerConnection` | `services/mcp/types.ts` | Connected \| Failed \| NeedsAuth \| Pending \| Disabled. |
+| `performMCPOAuthFlow` | `services/mcp/auth.ts` | OAuth for `needs-auth` servers. |
+| `appState.mcp` | `state/AppStateStore.ts` | Single source of truth: clients, tools, commands, resources. |
+| `startMCPServer` | `entrypoints/mcp.ts` | Claude Code as an MCP server. |

--- a/docs/internals/09-agents-coordinator-tasks.md
+++ b/docs/internals/09-agents-coordinator-tasks.md
@@ -1,0 +1,140 @@
+# 09 — Agents, Coordinator, Tasks & Teams
+
+> Claude Code can spawn sub-agents — nested `query()` loops with their own tool sets and context.
+> This doc covers `AgentTool`, fork sub-agents, coordinator mode, the task lifecycle, and
+> inter-agent messaging/teams.
+
+← [08 — MCP](08-mcp.md) · [Index](README.md) · Next → [10 — UI & State](10-ui-state-rendering.md)
+
+---
+
+## The core idea: agents are nested query loops
+
+A sub-agent is not a separate process by default — it's another invocation of `query()`
+(see [02](02-query-loop.md)) running in the same process, distinguished by a unique
+`toolUseContext.agentId` and an incremented `queryTracking.depth`.
+
+```mermaid
+flowchart TD
+    MAIN["main thread query()<br/>agentId = undefined, depth 0"] --> AT["AgentTool.call()"]
+    AT --> RUN["runAgent() - tools/AgentTool/runAgent.ts"]
+    RUN --> SUBQ["query({ ...isolated context, agentId, depth+1 })"]
+    SUBQ --> YIELD["yields its own messages"]
+    YIELD --> NOTIF["on completion: task-notification<br/>enqueued to messageQueueManager"]
+    NOTIF --> MAIN
+```
+
+- **Sync agents** — the parent `await`s `runAgent()`; the parent's turn blocks until the child finishes.
+- **Async/background agents** — `registerAsyncAgent()` creates a `LocalAgentTask`, then the child runs
+  fire-and-forget. Its result returns later as a `<task-notification>` drained by the main loop on a
+  subsequent turn. Auto-backgrounding kicks in for long-running agents.
+- **Isolation** — each async agent gets its own `AgentContext` via `AsyncLocalStorage`
+  (`utils/agentContext.ts`) so concurrent agents don't clobber each other's telemetry/context.
+
+---
+
+## Agent definitions
+
+`AgentDefinition` (`tools/AgentTool/loadAgentsDir.ts`) describes an agent type: `agentType`,
+`whenToUse`, allowed `tools[]` / `disallowedTools[]`, `skills`, `mcpServers`, `hooks`, `model`
+(`'inherit'` or an alias), `effort`, `permissionMode`, `maxTurns`, `memory` scope, and `isolation`
+(`'worktree'` | `'remote'`). Sources:
+
+- **Built-in** (`builtInAgents.ts`) — e.g. `Explore`, `Plan`; `getSystemPrompt()` is computed per turn.
+- **Custom** (`.claude/agents/*.md` + `--agents` JSON) — user/project/policy defined.
+- **Plugin** — agents shipped by plugins.
+
+`resolveAgentTools()` (`tools/AgentTool/agentToolUtils.ts`) turns the agent's `tools` (names or `'*'`)
+into the actual `Tool[]`, after dedup and permission filtering.
+
+---
+
+## Fork sub-agents
+
+When `AgentTool` is called with **no `subagent_type`** and the `FORK_SUBAGENT` gate is on, it spawns
+a *fork*: a child that inherits the parent's **full conversation context** *and* its **rendered
+system prompt bytes** (`renderedSystemPrompt`, `Tool.ts:299`). The point is **prompt-cache sharing** —
+every fork produces a byte-identical request prefix up to the per-child directive, so forks hit the
+cache instead of re-paying for the prompt. `buildForkedMessages()` (`forkSubagent.ts`) clones the
+parent's assistant message, adds placeholder tool-results, and appends the fork directive. Recursive
+forks are guarded against. Forks always run async (unified task-notification model).
+
+---
+
+## Coordinator mode
+
+```mermaid
+flowchart TD
+    CO["Coordinator (own system prompt)<br/>coordinator/coordinatorMode.ts"] --> W1["worker agent 1"]
+    CO --> W2["worker agent 2"]
+    CO --> W3["worker agent 3"]
+    W1 -->|"task-notification on done"| CO
+    W2 -->|"task-notification on done"| CO
+    W3 -->|"task-notification on done"| CO
+```
+
+`COORDINATOR_MODE` swaps the default system prompt for a coordinator prompt
+(`getCoordinatorSystemPrompt`, `coordinator/coordinatorMode.ts`) whose job is to *orchestrate*
+workers (spawned via `AgentTool`) for research/implementation/verification. Workers run async and
+**notify the coordinator on completion** rather than the coordinator polling them ("do not use one
+worker to check on another"). Coordinator mode and fork sub-agents are mutually exclusive — the
+coordinator owns orchestration.
+
+---
+
+## Tasks
+
+Async agents (and other long-running work) are modeled as **tasks** in `src/tasks/`. `TaskState`
+(`tasks/types.ts`) is a union covering local shell tasks, local agent tasks, remote agent tasks,
+in-process teammates, workflows, and monitors. Task state lives in `AppState.tasks[taskId]` so it
+survives backgrounding. The Task v2 tools (`TaskCreate/Get/Update/List/Stop/Output`) let the model
+create and inspect tasks. On completion, `enqueueAgentNotification()` builds the `<task-notification>`
+block and pushes it to the **message queue manager** (`utils/messageQueueManager.ts`), a
+process-global priority queue (`now` > `next` > `later`) drained by the main loop — which is also how
+queued user prompts and orphaned permission requests re-enter the conversation.
+
+---
+
+## Teams & inter-agent messaging
+
+```mermaid
+flowchart LR
+    A["agent A"] -->|SendMessage to:B| MB["mailbox / pendingUserMessages"]
+    MB --> B["agent B (drains on next loop)"]
+    TC["TeamCreateTool"] --> TEAM["team roster + context<br/>~/.claude/teams/team.json"]
+```
+
+- **`TeamCreateTool` / `TeamDeleteTool`** — create/tear down a team (roster, lead, shared context).
+- **`SendMessageTool`** — `{to, message, summary}`. For in-process teammates it queues into the
+  target's `pendingMessages`, drained when that teammate's loop next checks; for separate processes
+  (e.g. tmux teammates) it writes to a mailbox file the target polls.
+- **Team memory sync** (`utils/teamMemorySync/`) — a shared knowledge base across team members
+  (see [12 — Memory](12-plugins-skills-memory.md)).
+
+---
+
+## Concurrency model at a glance
+
+| Mode | Where it runs | Can show UI? | Result path |
+|---|---|---|---|
+| Sync sub-agent | in-process, blocks parent | via parent | returned directly to the tool result |
+| Async/background agent | in-process, fire-and-forget | no | `<task-notification>` via message queue |
+| Fork sub-agent | in-process, async | no | task-notification (cache-shared prefix) |
+| In-process teammate | in-process, own loop | yes (shares terminal) | mailbox / pendingMessages |
+| Remote agent (ant) | CCR / teleport | n/a | taskId + session URL |
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `AgentTool` | `tools/AgentTool/AgentTool.tsx` | Spawns sub-agents (sync/async/fork). |
+| `runAgent` | `tools/AgentTool/runAgent.ts` | Runs a sub-agent's `query()` loop, yields its messages. |
+| `AgentDefinition` / `loadAgentsDir` | `tools/AgentTool/loadAgentsDir.ts` | Agent type schema + loader. |
+| `buildForkedMessages` | `tools/AgentTool/forkSubagent.ts` | Fork context cloning for cache sharing. |
+| `getCoordinatorSystemPrompt` | `coordinator/coordinatorMode.ts` | Coordinator-mode prompt. |
+| `messageQueueManager` | `utils/messageQueueManager.ts` | Process-global priority queue (notifications, prompts). |
+| `TaskState` | `tasks/types.ts` | The task union; lives in `AppState.tasks`. |
+| `SendMessageTool` / `TeamCreateTool` | `tools/SendMessageTool/`, `tools/TeamCreateTool/` | Inter-agent messaging + teams. |
+| `AsyncLocalStorage<AgentContext>` | `utils/agentContext.ts` | Per-agent isolation. |

--- a/docs/internals/10-ui-state-rendering.md
+++ b/docs/internals/10-ui-state-rendering.md
@@ -1,0 +1,151 @@
+# 10 — UI, State & Rendering
+
+> Claude Code's UI is React rendered to the terminal via Ink. This doc covers the renderer, the
+> REPL's consumption of the `query()` stream, the AppState store, message rendering, and input.
+
+← [09 — Agents](09-agents-coordinator-tasks.md) · [Index](README.md) · Next → [11 — Bridge & Remote](11-bridge-remote-server.md)
+
+---
+
+## React, in a terminal
+
+The entire UI is React components rendering to the terminal via **Ink** (`src/ink/`), a custom
+React reconciler that lays out `Box`/`Text` nodes and paints them as ANSI text. A `ThemeProvider`
+wraps every render; a frame loop repaints on a fixed interval.
+
+```mermaid
+flowchart TD
+    RL["replLauncher.tsx<br/>launchRepl()"] --> RENDER["root.render(App > REPL)"]
+    RENDER --> INK["Ink instance (src/ink/ink.tsx)<br/>react-reconciler + terminal I/O + frame loop"]
+    INK --> PAINT["render-node-to-output -> ANSI text"]
+    APP["App.tsx providers:<br/>FpsMetrics > Stats > AppState"] --> REPL["REPL.tsx"]
+```
+
+---
+
+## The REPL: consuming the query stream
+
+`src/screens/REPL.tsx` (~5,000 lines) is the main interactive screen. On each user submission it
+calls `query(...)` and consumes the yielded events:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant REPL as REPL.tsx
+    participant Q as query()
+    participant MSG as messages state
+    participant Ink
+
+    User->>REPL: submit prompt (PromptInput)
+    REPL->>MSG: append user message
+    REPL->>Q: for await (event of query({messages, ...}))
+    loop each stream event
+        Q-->>REPL: onQueryEvent(event)
+        REPL->>MSG: setMessages (append or replace)
+        MSG-->>Ink: re-render Messages -> MessageRow
+        Ink-->>User: incremental terminal output
+    end
+    Q-->>REPL: return Terminal (turn done)
+    REPL->>REPL: capture metrics, reset to idle
+```
+
+- **`onQueryEvent`** routes each event through `handleMessageFromStream` (`utils/messages.ts`),
+  which turns raw stream events into `Message` objects and fires callbacks.
+- **Append vs. replace**: normal messages are appended; *ephemeral* progress messages (Bash/Sleep
+  ticks) are **replaced** in place to avoid unbounded array growth.
+- **Compact boundaries** reset the message list and bump a `conversationId` so React remounts the
+  rows (clearing stale memoization).
+- **Streaming separation**: in-progress thinking and tool-use blocks are held in separate streaming
+  state and merged into `messages` only when complete.
+
+---
+
+## State management — the AppState store
+
+There are **two** state systems; don't confuse them (see also [01 — Startup](01-startup.md#global-state-singleton--srcbootstrapstatets)):
+
+| Store | Where | Reactive? | Holds |
+|---|---|---|---|
+| **`AppState`** | `state/AppStateStore.ts` + `state/AppState.tsx` | Yes (React) | UI-reactive state: settings, model, permission context, MCP state, tasks, notifications, view mode |
+| **`bootstrap/state.ts`** | module singleton | No | Process-global: session id, cwd, cost counters, model override |
+
+The AppState store is a tiny subscription store (`state/store.ts`): `createStore(initial, onChange)`
+→ `{ getState, setState, subscribe }`. Components subscribe with `useAppState(selector)` via
+`useSyncExternalStore`, so a component only re-renders when *its* slice changes (`Object.is` gating).
+
+```mermaid
+flowchart LR
+    TOOLS["tools / query loop"] -->|getAppState / setAppState| STORE["AppState store"]
+    STORE -->|useAppState(selector)| COMP["React components (fine-grained re-render)"]
+    STORE --> ONCHANGE["onChangeAppState.ts<br/>side-effects: e.g. sync permission mode to CCR/SDK"]
+```
+
+`onChangeAppState.ts` is the single choke point for side-effects on state change (e.g. when the
+permission mode changes, it notifies the bridge/SDK). Tools reach state through
+`toolUseContext.getAppState()` — that's the bridge between the non-React engine and the React UI.
+
+### Context providers (`src/context/`)
+`AppState`, `FpsMetrics`, `Stats` (token/cost aggregation), `notifications` (toasts),
+`overlay`/`modal`/`promptOverlay` (dialogs), `QueuedMessage` + `mailbox` (teammate messaging),
+and `voice` (ant-only, eliminated from external builds).
+
+---
+
+## Message rendering
+
+```mermaid
+flowchart TD
+    MS["Messages.tsx<br/>normalize -> group tool uses -> reorder"] --> ROW["MessageRow.tsx (memoized per UUID)"]
+    ROW --> AT["AssistantTextMessage (markdown)"]
+    ROW --> TU["AssistantToolUseMessage (params/result/streaming)"]
+    ROW --> TH["AssistantThinkingMessage (collapsible)"]
+    ROW --> UT["UserTextMessage"]
+    ROW --> ATT["AttachmentMessage (images/PDFs/results)"]
+    ROW --> SYS["System / APIError / HookProgress"]
+    MS -.->|fullscreen| VML["VirtualMessageList (windowed)"]
+```
+
+`Messages.tsx` normalizes the raw list (drops compact boundaries, groups adjacent tool-use/result
+pairs), then renders each via a type-specific component. A `VirtualMessageList` provides windowed
+rendering + search in fullscreen mode.
+
+---
+
+## Input handling
+
+`PromptInput` composes several hooks:
+
+| Hook | Role |
+|---|---|
+| `useTextInput` | Cursor, history, kill-ring (Emacs-style editing). |
+| `useVimInput` | Vim normal/insert state machine wrapping `useTextInput`. |
+| `usePasteHandler` | Large-paste coalescing, clipboard image extraction, drag-drop file paths. |
+| `useKeybinding` / `useGlobalKeybindings` | User-configurable + global key handlers. |
+
+Submission → `handlePromptSubmit` (`utils/handlePromptSubmit.ts`) → appends a user message and
+kicks the query.
+
+---
+
+## Print / non-interactive mode
+
+`src/cli/print.ts` is the headless path (`-p`). It runs the same `query()` but **does not render
+with Ink** — instead it accumulates messages and emits text or JSON (`stream-json` for SDK
+consumers) to stdout. It runs post-turn hooks synchronously and doesn't mutate React state. Same
+engine, different sink.
+
+---
+
+## Key symbols
+
+| Symbol | File:line | Role |
+|---|---|---|
+| `launchRepl` | `replLauncher.tsx` | Mount the App + REPL tree. |
+| `onQueryEvent` | `screens/REPL.tsx` | Consume `query()` stream events → update messages. |
+| `handleMessageFromStream` | `utils/messages.ts` | Stream events → `Message` objects + callbacks. |
+| `createStore` / `useAppState` | `state/store.ts`, `state/AppState.tsx` | The subscription store + selector hook. |
+| `onChangeAppState` | `state/onChangeAppState.ts` | Side-effects on state change. |
+| `Messages` / `MessageRow` | `components/` | Message list + per-message rendering. |
+| `useTextInput` / `useVimInput` / `usePasteHandler` | `hooks/` | Input editing stack. |
+| `print` | `cli/print.ts` | Headless/SDK output path. |

--- a/docs/internals/11-bridge-remote-server.md
+++ b/docs/internals/11-bridge-remote-server.md
@@ -1,0 +1,110 @@
+# 11 — Bridge, Remote & Server
+
+> Three different ways a Claude Code session can be driven from outside the terminal: the IDE/web
+> **bridge** (Remote Control / CCR), **remote sessions** (desktop/mobile handoff), and **server
+> mode** (local PTY server). They look similar but are distinct subsystems.
+
+← [10 — UI & State](10-ui-state-rendering.md) · [Index](README.md) · Next → [12 — Plugins, Skills, Memory](12-plugins-skills-memory.md)
+
+---
+
+## Three surfaces at a glance
+
+```mermaid
+flowchart TB
+    subgraph BR["Bridge (src/bridge) — CCR"]
+        WEB["claude.ai / IDE / mobile"] <-->|"Remote Control API + WS"| BRG["bridge daemon"]
+        BRG <-->|stdin/stdout + control msgs| SESS["child claude session(s)"]
+    end
+    subgraph RM["Remote (src/remote)"]
+        DESK["desktop / mobile app"] <-->|"WebSocket /v1/sessions/ws"| CCRSESS["existing CCR session"]
+    end
+    subgraph SV["Server (src/server)"]
+        LOCAL["local WS client"] <-->|"/sessions/ws (PTY)"| PTY["node-pty session"]
+    end
+```
+
+| Subsystem | What it is | Transport | Direction |
+|---|---|---|---|
+| **Bridge** (`src/bridge/`) | A local daemon that polls the Remote Control (CCR) service for work and **spawns child `claude` sessions**, bridging their stdio + permission prompts to a web/IDE client. | Environments API poll + WebSocket ingress (v1) or direct OAuth→session→SSE (v2) | bidirectional |
+| **Remote** (`src/remote/`) | A WebSocket client to an **already-running** CCR session (desktop/mobile cowork/handoff). | WebSocket `/v1/sessions/ws/{id}/subscribe` | peer |
+| **Server** (`src/server/`) | A standalone PTY server exposing local sessions over WebSocket, with rate limits and a crash-recovery index. | local `/sessions/ws` | peer |
+
+---
+
+## The bridge (CCR / Remote Control)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Web as claude.ai / IDE
+    participant CCR as Remote Control API
+    participant Bridge as bridge daemon
+    participant Sess as child claude session
+
+    Web->>CCR: user message / control
+    Bridge->>CCR: poll for work (v1) / SSE read (v2)
+    CCR-->>Bridge: ingress message
+    Bridge->>Bridge: normalizeControlMessageKeys + dedup
+    Bridge->>Sess: route to stdin / permission callback
+    Sess-->>Bridge: SDKMessage stream (assistant, tool_use, ...)
+    Bridge->>CCR: post events (HybridTransport / CCRClient)
+    CCR-->>Web: render
+```
+
+- **Activation** — `isBridgeEnabled()` (`bridge/bridgeEnabled.ts`) gates on a GrowthBook flag +
+  subscriber status; `feature('BRIDGE_MODE')` gates it out of external builds at compile time.
+- **Two implementations** — *v1* (env-based): a long-lived daemon polling the Environments API and
+  dispatching work (`bridgeMain.ts`, `replBridge.ts`). *v2* (env-less): direct OAuth → create session
+  → `/bridge` endpoint → SSE read + CCR write (`remoteBridgeCore.ts`), REPL-only.
+- **Protocol** — messages are the SDK `SDKMessage` discriminated union (user/assistant/system/
+  tool_use/tool_result/control_request/control_response). `handleIngressMessage`
+  (`bridgeMessaging.ts`) parses, normalizes key casing (mobile clients send camelCase), routes by
+  type, and dedups by UUID. Outbound goes through a `ReplBridgeTransport` abstraction (v1
+  HybridTransport WS-POST vs v2 SSETransport + CCRClient), with an SSE high-water mark so a transport
+  swap resumes instead of replaying from zero.
+- **Auth (JWT)** — `jwtUtils.ts` decodes the `exp` claim and proactively refreshes ~5 min before
+  expiry, delivering fresh tokens to the transport. Bridge API calls carry `Authorization: Bearer`
+  and retry once on `401`.
+- **Permission routing** — `bridgePermissionCallbacks.ts`: a `control_request` carries the tool +
+  input to the web client; a `control_response` returns `{ behavior: 'allow'|'deny', updatedInput?,
+  updatedPermissions? }`. This is how a browser can answer the permission prompt the CLI would
+  otherwise show in the terminal.
+- **Crash recovery** — a "bridge pointer" file lets a restarted session re-attach; recovery can
+  fan out across worktree siblings.
+
+---
+
+## Remote sessions (`src/remote/`)
+
+A *different* protocol for desktop/mobile cowork. `RemoteSessionManager` opens a WebSocket
+(`SessionsWebSocket`) to an existing CCR session at `/v1/sessions/ws/{id}/subscribe`, authenticated
+with an OAuth bearer token. It receives the `SDKMessage` + control stream and posts user messages via
+HTTP. Reconnect uses bounded backoff; permanent close codes (e.g. unauthorized) stop retrying.
+Unlike the bridge, it does **not** spawn child sessions — it's a viewer/driver of a server-side
+session.
+
+---
+
+## Server mode (`src/server/`)
+
+A standalone server that spawns **node-pty pseudo-terminals**, one per WebSocket client, exposing
+local sessions over `/sessions/ws`. `SessionManager` enforces per-user rate limits (e.g. sessions
+per hour), concurrent-session caps, and a session index for resumption across restarts. States:
+`starting → running → detached → stopping → stopped`. `DirectConnectSessionManager` wraps a session
+for a direct WebSocket client, parsing inbound control requests (permission prompts) and forwarding
+SDK messages. This is **local** — clients connect to this process, not to CCR.
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `isBridgeEnabled` / `isBridgeEnabledBlocking` | `bridge/bridgeEnabled.ts` | Runtime gate (GrowthBook + OAuth). |
+| `handleIngressMessage` | `bridge/bridgeMessaging.ts` | Parse/normalize/route/dedup inbound messages. |
+| `ReplBridgeTransport` | `bridge/replBridgeTransport.ts` | v1/v2 transport abstraction. |
+| `createTokenRefreshScheduler` | `bridge/jwtUtils.ts` | Proactive JWT refresh. |
+| `BridgePermissionResponse` | `bridge/bridgePermissionCallbacks.ts` | allow/deny + updated input/permissions. |
+| `RemoteSessionManager` / `SessionsWebSocket` | `remote/` | Desktop/mobile session over WebSocket. |
+| `SessionManager` / `DirectConnectSessionManager` | `server/` | PTY server + direct-connect wrapper. |

--- a/docs/internals/12-plugins-skills-memory.md
+++ b/docs/internals/12-plugins-skills-memory.md
@@ -1,0 +1,113 @@
+# 12 — Plugins, Skills, Memory & Output Styles
+
+> The extensibility surfaces (skills, plugins) and the persistent memory system, plus output styles
+> that reshape the system prompt.
+
+← [11 — Bridge & Remote](11-bridge-remote-server.md) · [Index](README.md) · Next → [13 — Build & Config](13-build-config-flags.md)
+
+---
+
+## Skills
+
+A **skill** is a reusable prompt-command (markdown with frontmatter) the model can invoke via the
+`SkillTool`, or a user can run as a slash command.
+
+```mermaid
+flowchart TD
+    SRC1["bundled skills<br/>registerBundledSkill()"] --> REG
+    SRC2[".claude/skills/*.md<br/>loadSkillsDir.ts"] --> REG
+    SRC3["plugin skills"] --> REG
+    REG["command registry (commands.ts)"] --> TOOL["SkillTool"]
+    TOOL --> MODE{execution mode}
+    MODE -->|inline| INL["expand prompt + allowedTools + model override<br/>into the current context"]
+    MODE -->|fork| FRK["spawn isolated sub-agent<br/>(own token budget) - see 09"]
+    MODE -->|remote (ant)| RMT["load from cache, inject as user message"]
+```
+
+- **Sources** — bundled (compiled in via `registerBundledSkill`, `src/skills/bundledSkills.ts`),
+  on-disk (`.claude/skills/`, user, policy dirs via `loadSkillsDir.ts`), and plugin skills.
+- **Frontmatter** — `name`, `description`, `whenToUse`, optional `model`, `effort`, `allowedTools`, `hooks`.
+- **Execution** (`tools/SkillTool/SkillTool.ts`) — *inline* (expand into the current turn), *forked*
+  (isolated sub-agent with its own budget; `addInvokedSkill()` records it so compaction preserves it),
+  or *remote* (ant-only experimental).
+- **Skill search** (`EXPERIMENTAL_SKILL_SEARCH`) — background discovery/prefetch of relevant skills,
+  injected as attachments (see [03 — Attachments](03-context-and-prompts.md#attachments--prefetch-extra-context-injected-mid-turn)).
+
+---
+
+## Plugins
+
+A **plugin** bundles skills, hooks, MCP servers, and/or output styles under one source id
+(`name@marketplace`).
+
+- **Built-in plugins** — registered in `src/plugins/builtinPlugins.ts`; enabled/disabled via
+  `settings.enabledPlugins` with a `defaultEnabled` fallback.
+- **Loading** — `src/services/plugins/pluginOperations.ts` (pure install/enable/disable/update
+  operations) + `utils/plugins/pluginLoader.ts` (read manifests/metadata).
+- **What they extend** — skills (→ commands), hooks (auto-injected), MCP servers (loaded at startup),
+  output styles (can be force-applied while the plugin is enabled).
+
+```mermaid
+flowchart LR
+    P["plugin (name@marketplace)"] --> SK["skills -> commands"]
+    P --> HK["hooks"]
+    P --> MC["MCP servers"]
+    P --> OS["output styles"]
+```
+
+---
+
+## Memory
+
+File-based, directory-scoped persistent memory with an optional shared team layer.
+
+```mermaid
+flowchart TD
+    subgraph AUTO["Auto memory (per project)"]
+        IDX["MEMORY.md (index, ~200 lines / 25KB cap)"]
+        FILES["topic files w/ YAML frontmatter<br/>type: user|feedback|project|reference"]
+    end
+    subgraph TEAM["Team memory (optional, nested)"]
+        TIDX["team/MEMORY.md"]
+        SYNC["synced via API across org members per repo"]
+    end
+    LOAD["loadMemoryPrompt() (memdir/memdir.ts)"] --> CTX["injected into conversation context (getUserContext)"]
+    EXTRACT["extractMemories (session-end agent)"] --> AUTO
+    AUTO --> LOAD
+    TEAM --> LOAD
+```
+
+- **Location** — `~/.claude/projects/{git-root-hash}/memory/` (overridable). `MEMORY.md` is the index
+  loaded into every conversation; topic files carry frontmatter (`name`, `description`, `type`, tags).
+- **Loading** — `loadMemoryPrompt()` (`memdir/memdir.ts`) builds the memory section of the prompt
+  (dispatching to KAIROS daily-log / combined team / plain variants by feature flag), entrypoint
+  truncated to a line + byte cap.
+- **Extraction** — `services/extractMemories/` runs a background agent at session end (`EXTRACT_MEMORIES`)
+  to scan the conversation for memory-worthy facts.
+- **Team sync** — `services/teamMemorySync/` pulls at session start and pushes at session end
+  (ETag-tracked, delta uploads), with a secret scanner blocking sensitive data and deletions that
+  don't propagate. Team vs. private scope is tagged in frontmatter.
+
+---
+
+## Output styles
+
+Output styles (`src/constants/outputStyles.ts`, e.g. `default`, `Explanatory`, `Learning`) are
+system-prompt overrides with optional `keepCodingInstructions`. Resolution
+(`getOutputStyleConfig`): forced plugin style → `settings.outputStyle` → built-in default. Custom
+styles can be defined in `.claude/output-styles/*.md`. The selected style is injected as the
+`# Output Style` section of the system prompt (see [03](03-context-and-prompts.md)).
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| `registerBundledSkill` | `skills/bundledSkills.ts` | Register a compiled-in skill. |
+| `loadSkillsDir` | `skills/loadSkillsDir.ts` | Load on-disk skills. |
+| `SkillTool` | `tools/SkillTool/SkillTool.ts` | Inline/fork/remote skill execution. |
+| `getBuiltinPlugins` | `plugins/builtinPlugins.ts` | Enabled/disabled plugin resolution. |
+| `loadMemoryPrompt` | `memdir/memdir.ts` | Build the memory prompt section. |
+| `getAutoMemPath` | `memdir/paths.ts` | Resolve the memory directory. |
+| `getOutputStyleConfig` | `constants/outputStyles.ts` | Resolve the active output style. |

--- a/docs/internals/13-build-config-flags.md
+++ b/docs/internals/13-build-config-flags.md
@@ -1,0 +1,126 @@
+# 13 — Build System, Feature Flags & Config
+
+> How the source becomes a runnable binary, how `bun:bundle` feature flags strip dead code, and how
+> settings are validated (Zod) and migrated across versions.
+
+← [12 — Plugins, Skills, Memory](12-plugins-skills-memory.md) · [Index](README.md)
+
+---
+
+## Build pipeline
+
+```mermaid
+flowchart TD
+    SRC["src/ (TypeScript, ESM, absolute src/ imports)"] --> EB["scripts/build-bundle.ts (esbuild)"]
+    EB --> RES["src-resolver plugin<br/>(maps src/ imports via tsconfig baseUrl)"]
+    EB --> SHIM["alias bun:bundle ->\nsrc/shims/bun-bundle.ts (dev)\nor inlined constants (prod Bun)"]
+    EB --> EXT["external: node builtins, native addons"]
+    EB --> OUT["single-file bundle (Node 20 / Bun)"]
+    OUT --> PKG["scripts/package-npm.ts -> npm package"]
+```
+
+- **Entry**: `scripts/build-bundle.ts` configures esbuild (Node 20 target, ESM, single file, tree-shaking).
+- **`src/` imports** are resolved by a plugin honoring `tsconfig.json`'s `baseUrl: "."` (so
+  `src/foo/bar.js` resolves to the TS source).
+- **Dev vs prod**: `bun run build` (esbuild) vs `build:prod` (`--minify`). `scripts/dev.ts` runs the
+  CLI in dev mode; `scripts/package-npm.ts` produces the publishable package.
+- **Runtime**: Bun (`engines.bun >= 1.1.0`), which gives native TSX and the `bun:bundle` macro.
+
+> This leaked tree has a community-added secondary build path (`scripts/bun-plugin-shims.ts`,
+> runtime shims, the `prompts/` rebuild guide) for running it **outside** Anthropic's Bun toolchain.
+> That scaffolding is *not* part of the original CLI — see the repo root `prompts/` and `docker/`.
+
+---
+
+## Feature flags — build-time dead-code elimination
+
+`feature('X')` is imported from `bun:bundle`. In production Bun builds, each call is replaced by a
+constant at bundle time, so `if (feature('X')) { ... }` branches that are off get **tree-shaken
+away entirely** — the code (and its string literals) never ships. In dev, a shim
+(`src/shims/bun-bundle.ts`) reads `CLAUDE_CODE_X` env vars with defaults.
+
+```mermaid
+flowchart LR
+    CODE["if (feature('VOICE_MODE')) { require('./voice') }"] --> PROD{prod Bun build?}
+    PROD -->|"flag off"| STRIP["branch removed (dead-code elim)"]
+    PROD -->|"flag on"| KEEP["branch kept"]
+    PROD -->|dev| ENV["runtime check vs CLAUDE_CODE_VOICE_MODE"]
+```
+
+This is *different* from GrowthBook runtime flags (see [07 — Services](07-services-api-auth.md)):
+`feature()` is compile-time (what ships), GrowthBook is runtime (what's enabled for this user/session).
+
+### Notable flags
+
+| Flag | Gates |
+|---|---|
+| `PROACTIVE` / `KAIROS` | Proactive/assistant autonomous modes |
+| `BRIDGE_MODE` | IDE/web bridge ([11](11-bridge-remote-server.md)) |
+| `COORDINATOR_MODE` | Multi-agent coordinator ([09](09-agents-coordinator-tasks.md)) |
+| `FORK_SUBAGENT` | Fork sub-agents ([09](09-agents-coordinator-tasks.md)) |
+| `VOICE_MODE` | Voice I/O |
+| `CONTEXT_COLLAPSE` / `HISTORY_SNIP` / `REACTIVE_COMPACT` / `CACHED_MICROCOMPACT` | Compaction strategies ([03](03-context-and-prompts.md)) |
+| `TOKEN_BUDGET` | `+500k`-style auto-continue ([02](02-query-loop.md)) |
+| `EXPERIMENTAL_SKILL_SEARCH` | Skill discovery/prefetch ([12](12-plugins-skills-memory.md)) |
+| `EXTRACT_MEMORIES` / `TEAMMATE` | Memory extraction + team memory ([12](12-plugins-skills-memory.md)) |
+| `WORKFLOW_SCRIPTS` | Workflow commands |
+| `AGENT_TRIGGERS` / `MONITOR_TOOL` / `BG_SESSIONS` | Scheduling, monitoring, background sessions |
+| `BREAK_CACHE_COMMAND` | Cache-breaking debug tool (ant) |
+
+(Flags are read across the codebase; this is a representative, not exhaustive, list.)
+
+---
+
+## Config schemas & migrations
+
+```mermaid
+flowchart TD
+    FILES["settings sources:<br/>managed > flag > local > project > user"] --> ZOD["Zod schemas<br/>utils/settings/types.ts, schemas/"]
+    ZOD --> VALID["validated settings object"]
+    VALID --> APP["AppState / permission context / hooks"]
+    MIG["migrations/ (run at startup, idempotent)"] --> FILES
+```
+
+- **Validation** — settings are Zod-validated (`utils/settings/types.ts`, `schemas/`). Hook schemas
+  live in `schemas/hooks.ts` (command/prompt/HTTP hooks, with `if` conditions in permission-rule syntax).
+  `lazySchema()` avoids circular-dependency issues at module load.
+- **Sources & precedence** — managed/policy (highest) → flag → local (`.claude/settings.local.json`)
+  → project (`.claude/settings.json`) → user (`~/.claude/settings.json`).
+- **Migrations** — `src/migrations/` holds idempotent transforms run at startup (e.g. remapping model
+  aliases on upgrade, moving a setting from global config into `settings.json`). Each checks state and
+  only writes if needed.
+
+### Config storage locations
+
+| Path | Holds |
+|---|---|
+| `~/.claude/.claude` | App state (auth, telemetry opt-in) |
+| `~/.claude/settings.json` | User settings (prefs, plugins, hooks) |
+| `.claude/settings.json` | Project settings (committed) |
+| `.claude/settings.local.json` | Local/session overrides (gitignored) |
+| managed settings file | Admin-controlled (enterprise) |
+
+---
+
+## Key symbols
+
+| Symbol | File | Role |
+|---|---|---|
+| build entry | `scripts/build-bundle.ts` | esbuild config, `src-resolver`, `bun:bundle` alias. |
+| `feature` | `bun:bundle` (shim: `src/shims/bun-bundle.ts`) | Build-time flag → dead-code elimination. |
+| settings schema | `utils/settings/types.ts`, `schemas/` | Zod validation of all config. |
+| migrations | `src/migrations/` | Idempotent config upgrades at startup. |
+| `lazySchema` | schema utils | Break circular deps in schema definitions. |
+
+---
+
+## That's the whole engine
+
+You've now got the full picture: [boot](01-startup.md) → [the loop](02-query-loop.md) →
+[what it sends the model](03-context-and-prompts.md) → [tools](04-tools.md) /
+[commands](05-commands.md) gated by [permissions](06-permissions.md), riding on
+[services](07-services-api-auth.md), extended by [MCP](08-mcp.md),
+[agents](09-agents-coordinator-tasks.md), and [skills/plugins/memory](12-plugins-skills-memory.md),
+rendered by [React+Ink](10-ui-state-rendering.md), reachable via
+[bridge/remote/server](11-bridge-remote-server.md), and shipped by this build system.
+Back to the [Index](README.md).

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,0 +1,222 @@
+# Claude Code — Internal Architecture (Deep Dive)
+
+> A complete, code-grounded explanation of how the Claude Code CLI works internally:
+> how it boots, how it talks to the LLM, how tools run, how permissions gate them,
+> how context is kept inside the window, and how every subsystem fits together.
+
+This is the **deep-dive** companion to the higher-level [`docs/architecture.md`](../architecture.md).
+It is written for someone who wants to *understand or modify* the engine, not just use it.
+
+---
+
+## How to read this
+
+Start here for the big picture and the master diagrams, then jump into any subsystem doc.
+The **single most important file in the whole codebase is `src/query.ts`** — the agentic
+loop. If you only read one deep-dive, read [02 — The Query Loop](02-query-loop.md).
+
+| # | Doc | What it covers |
+|---|-----|----------------|
+| 00 | **this file** | Master diagrams, layer model, glossary, the 60-second mental model |
+| 01 | [Startup & Entrypoints](01-startup.md) | `claude` → REPL: boot sequence, entrypoints, parallel prefetch, CLI flags, global state |
+| 02 | [The Query Loop (LLM engine)](02-query-loop.md) | The agentic `while(true)` loop, turn lifecycle, streaming, recovery paths |
+| 03 | [Context & Prompts](03-context-and-prompts.md) | System prompt assembly, context gathering, prompt caching, the 5-layer compaction stack |
+| 04 | [Tool System](04-tools.md) | The `Tool` contract, registry, schema→API, parallel execution, deferred tools |
+| 05 | [Command System](05-commands.md) | Slash commands: the 3 command types, dispatch, prompt-commands → LLM |
+| 06 | [Permission System](06-permissions.md) | Permission modes, the decision pipeline, rules, the auto classifier, hooks |
+| 07 | [Services: API, Auth, Analytics, Cost](07-services-api-auth.md) | Anthropic client, retry/fallback, OAuth/keychain, GrowthBook, cost tracking |
+| 08 | [MCP Integration](08-mcp.md) | Client (connecting to servers) + Claude Code as a server + the explorer server |
+| 09 | [Agents, Coordinator, Tasks, Teams](09-agents-coordinator-tasks.md) | Sub-agents, forks, coordinator mode, task lifecycle, inter-agent messaging |
+| 10 | [UI, State & Rendering](10-ui-state-rendering.md) | React + Ink, AppState store, message rendering, input handling |
+| 11 | [Bridge, Remote & Server](11-bridge-remote-server.md) | IDE/web bridge (CCR), remote desktop/mobile sessions, PTY server mode |
+| 12 | [Plugins, Skills, Memory, Output Styles](12-plugins-skills-memory.md) | Extensibility + persistent memory |
+| 13 | [Build System, Feature Flags, Config](13-build-config-flags.md) | esbuild/Bun bundle, `bun:bundle` dead-code elimination, Zod schemas, migrations |
+
+> **Note on line numbers.** File:line references throughout these docs are navigation
+> anchors against this snapshot of the source. The structure is reliable; exact line
+> numbers may drift by a few lines. When in doubt, grep for the named symbol.
+>
+> **Note on era.** This source predates Opus 4.8 — the prompt hardcodes
+> `FRONTIER_MODEL_NAME = 'Claude Opus 4.6'` (`src/constants/prompts.ts:118`). Treat model
+> IDs as a point-in-time snapshot.
+
+---
+
+## The 60-second mental model
+
+Claude Code is **not a chatbot with some commands bolted on**. It is an *agentic loop*:
+
+1. You type something. It becomes a `user` message.
+2. The loop builds a request — **system prompt + context + full message history + the tool catalog** — and streams it to the Anthropic API.
+3. The model streams back text and/or **tool-use requests** (structured "please run Bash with these args").
+4. The loop **executes those tools locally**, turns each result into a `tool_result` message, appends them to the history, and **calls the model again**.
+5. Repeat until the model responds with *no* tool requests. That's the end of the turn.
+
+Everything else — the React/Ink terminal UI, the permission prompts, MCP servers, sub-agents,
+compaction, the IDE bridge — is machinery hanging off that five-step spine. The model never
+touches your machine directly; it only emits structured requests that **the loop** chooses to
+execute (after permission checks).
+
+---
+
+## Layer model
+
+```mermaid
+flowchart TB
+    subgraph UI["UI Layer — React + Ink (src/ink, src/components, src/screens)"]
+        REPL["REPL.tsx<br/>interactive screen"]
+        PRINT["cli/print.ts<br/>headless / -p mode"]
+        INPUT["PromptInput + input hooks<br/>(text, vim, paste, keybindings)"]
+    end
+
+    subgraph CORE["Core Engine"]
+        QUERY["query.ts<br/>THE agentic loop"]
+        TOOLS["Tool system<br/>(Tool.ts, tools/, tools.ts)"]
+        PERM["Permission system<br/>(hooks/toolPermission/)"]
+        CTX["Context + Prompts<br/>(context.ts, constants/prompts.ts)"]
+        CMDS["Command system<br/>(commands.ts, commands/)"]
+    end
+
+    subgraph SVC["Services Layer (src/services)"]
+        API["api/<br/>Anthropic client, retry, cost"]
+        AUTH["oauth/<br/>auth + keychain"]
+        MCP["mcp/<br/>MCP client"]
+        COMPACT["compact/<br/>context compaction"]
+        ANALYTICS["analytics/<br/>GrowthBook + OTel"]
+    end
+
+    subgraph EXT["Extensibility & Multi-agent"]
+        AGENTS["AgentTool + coordinator/<br/>+ tasks/ + teams"]
+        SKILLS["skills/ + plugins/"]
+        MEM["memdir/ + extractMemories/"]
+    end
+
+    subgraph IO["External Surfaces"]
+        BRIDGE["bridge/ — IDE / web (CCR)"]
+        REMOTE["remote/ — desktop/mobile"]
+        SERVER["server/ — PTY server"]
+    end
+
+    LLM["Anthropic API<br/>(claude-* models)"]
+
+    INPUT --> REPL
+    REPL --> QUERY
+    PRINT --> QUERY
+    QUERY --> CTX
+    QUERY --> CMDS
+    QUERY --> TOOLS
+    TOOLS --> PERM
+    QUERY -->|callModel| API
+    API --> LLM
+    QUERY --> COMPACT
+    API --> AUTH
+    API --> ANALYTICS
+    TOOLS --> MCP
+    TOOLS --> AGENTS
+    TOOLS --> SKILLS
+    QUERY --> MEM
+    BRIDGE --> QUERY
+    REMOTE --> QUERY
+    SERVER --> QUERY
+```
+
+---
+
+## Master diagram: one user turn, end to end
+
+This is the core control flow. Every box maps to real code in `src/query.ts` unless noted.
+
+```mermaid
+flowchart TD
+    START([User submits a message]) --> ASM
+
+    subgraph TURN["query() turn — src/query.ts queryLoop while(true)"]
+        ASM["Reduce context:<br/>tool-result budget → snip → microcompact<br/>→ context-collapse → autocompact"]
+        ASM --> BUILD["Assemble request:<br/>systemPrompt + systemContext (git)<br/>+ userContext (CLAUDE.md, date)<br/>+ messages + tools"]
+        BUILD --> CALL["deps.callModel(...)<br/>→ queryModelWithStreaming<br/>→ anthropic.beta.messages.create (stream)"]
+        CALL --> STREAM{"Stream events"}
+        STREAM -->|text / thinking| YIELD["yield to UI<br/>(renders live)"]
+        STREAM -->|tool_use block| COLLECT["collect tool_use<br/>needsFollowUp = true<br/>StreamingToolExecutor starts early"]
+        YIELD --> DONE{needsFollowUp?}
+        COLLECT --> DONE
+        DONE -->|"No tool calls"| STOPHOOK["run stop-hooks<br/>+ token-budget check"]
+        STOPHOOK --> COMPLETE([return: completed])
+        DONE -->|"Tool calls present"| EXEC["execute tools:<br/>runTools / StreamingToolExecutor"]
+        EXEC --> PERMCHK["per tool:<br/>validate input → canUseTool<br/>→ PreToolUse hooks → call()"]
+        PERMCHK --> RESULTS["each result → tool_result message"]
+        RESULTS --> APPEND["state.messages =<br/>[...messages, assistant, tool_results]"]
+        APPEND --> ASM
+    end
+
+    CALL -.->|"413 / max_tokens / overloaded"| RECOVER["recovery paths:<br/>model fallback · reactive compact<br/>· token escalate · budget continue"]
+    RECOVER -.-> ASM
+```
+
+The two arrows that *make it an agent*:
+- **`APPEND → ASM`** (`src/query.ts:1714`): tool results are appended to history and the loop repeats.
+- **`DONE → STOPHOOK → COMPLETE`** (`src/query.ts:1062`): when the model stops asking for tools, the turn ends.
+
+---
+
+## What actually gets sent to the LLM
+
+```mermaid
+flowchart LR
+    subgraph REQ["Anthropic Messages request"]
+        direction TB
+        SP["system:<br/>default Claude Code prompt<br/>(or agent/coordinator/custom)<br/>+ git status appended"]
+        MSGS["messages:<br/>CLAUDE.md + date (prepended)<br/>+ conversation history<br/>+ tool_use / tool_result pairs"]
+        TOOLS["tools:<br/>~40 tool defs as JSON Schema<br/>(from each tool's Zod inputSchema)"]
+        CFG["config:<br/>model, thinking budget,<br/>cache_control breakpoints,<br/>beta headers, task_budget"]
+    end
+    SP --> LLM["claude-* model"]
+    MSGS --> LLM
+    TOOLS --> LLM
+    CFG --> LLM
+    LLM --> RESP["stream: text · thinking · tool_use blocks"]
+```
+
+Sources:
+- **System prompt** — `src/utils/systemPrompt.ts:41` (`buildEffectiveSystemPrompt`); text in `src/constants/prompts.ts`.
+- **System context** (git status) — `src/context.ts:116` (`getSystemContext`), appended at `query.ts:449`.
+- **User context** (CLAUDE.md + date) — `src/context.ts:155` (`getUserContext`), prepended at `query.ts:660`.
+- **Tools** — Zod schema → JSON Schema via `zodToJsonSchema()` (cached); see [04 — Tool System](04-tools.md).
+- **Prompt caching** — a hard design constraint; the `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` marker (`prompts.ts:114`) splits cacheable-static from session-dynamic. See [03 — Context & Prompts](03-context-and-prompts.md).
+
+---
+
+## Subsystem map (where things live)
+
+| Directory | Role | Deep-dive |
+|---|---|---|
+| `entrypoints/`, `bootstrap/` | Process boot, CLI parse, global state | [01](01-startup.md) |
+| `query.ts`, `query/`, `QueryEngine.ts` | The agentic loop & SDK wrapper | [02](02-query-loop.md) |
+| `context.ts`, `constants/prompts.ts`, `services/compact/` | Prompts, context, compaction | [03](03-context-and-prompts.md) |
+| `Tool.ts`, `tools/`, `tools.ts`, `services/tools/` | Tool contract, registry, execution | [04](04-tools.md) |
+| `commands.ts`, `commands/` | Slash commands | [05](05-commands.md) |
+| `hooks/toolPermission/`, `utils/permissions/` | Permission decisions | [06](06-permissions.md) |
+| `services/api/`, `services/oauth/`, `services/analytics/`, `cost-tracker.ts` | API, auth, telemetry, cost | [07](07-services-api-auth.md) |
+| `services/mcp/`, `tools/MCPTool/`, `mcp-server/` | Model Context Protocol | [08](08-mcp.md) |
+| `tools/AgentTool/`, `coordinator/`, `tasks/`, `tools/Team*`, `tools/SendMessageTool/` | Multi-agent | [09](09-agents-coordinator-tasks.md) |
+| `ink/`, `components/`, `screens/`, `state/`, `context/`, input `hooks/` | Terminal UI | [10](10-ui-state-rendering.md) |
+| `bridge/`, `remote/`, `server/` | External session surfaces | [11](11-bridge-remote-server.md) |
+| `skills/`, `plugins/`, `memdir/`, `outputStyles/`, `services/extractMemories/` | Extensibility + memory | [12](12-plugins-skills-memory.md) |
+| `scripts/`, `shims/`, `schemas/`, `migrations/` | Build, flags, config | [13](13-build-config-flags.md) |
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Turn** | One full `query()` invocation: model call → tools → model call → … until no tool requests. May span many API round-trips ("iterations"). |
+| **Iteration** | One pass of the `while(true)` loop = one API request + its tool executions. |
+| **Tool-use / tool-result** | The model's structured request to run a tool, and the message carrying the tool's output back. |
+| **`canUseTool`** | The permission function (`CanUseToolFn`) called before any tool runs. |
+| **`ToolUseContext`** | The big runtime context object threaded through the loop and into every tool (`src/Tool.ts:158`). |
+| **Compaction** | Summarizing/trimming history to stay under the context window. Five strategies — see [03](03-context-and-prompts.md). |
+| **Sub-agent** | A nested `query()` loop spawned by `AgentTool`, with its own `agentId` and tool set. |
+| **Bridge / CCR** | The IDE/web "Remote Control" layer that drives a CLI session from a browser. |
+| **`feature('X')`** | Build-time feature flag from `bun:bundle`; inactive branches are dead-code-eliminated. |
+| **`querySource`** | An enum tagging where a query came from (`repl_main_thread`, `agent:*`, `compact`, `sdk`, …); changes behavior in many places. |
+| **Ant-only** | Code gated to Anthropic-internal users (`USER_TYPE === 'ant'`). |


### PR DESCRIPTION
## Summary

Adds `docs/internals/` — a 14-part, code-grounded explanation of how the Claude Code CLI works internally, with 42 Mermaid architecture diagrams.

Covers, one doc per subsystem (each with file:line anchors + a key-symbols table):

- Startup & entrypoints, the agentic query loop, context/prompt assembly + compaction
- Tool system, slash commands, permissions
- Services (API/auth/analytics/cost), MCP, multi-agent/coordinator/tasks
- React+Ink UI/state, bridge/remote/server surfaces, plugins/skills/memory, build system + feature flags

Also adds a discoverability pointer from `docs/architecture.md`.

## Notes

- Documentation only — no changes to `src/`.
- Diagrams are Mermaid (render on GitHub). Start at `docs/internals/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal architecture documentation guide with Mermaid diagrams and detailed walkthroughs covering system startup, query loop execution, context and prompt building, tool mechanisms, slash commands, permissions, API authentication, MCP integration, multi-agent coordination, UI rendering, remote sessions, plugin/skill extensibility, and build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->